### PR TITLE
Optimize UI event handling to reduce main thread saturation

### DIFF
--- a/app/src/main/java/cn/classfun/droidvm/lib/daemon/VMEventHandler.java
+++ b/app/src/main/java/cn/classfun/droidvm/lib/daemon/VMEventHandler.java
@@ -145,6 +145,7 @@ public final class VMEventHandler implements
         var data = msg.optJSONObject("data");
         if (data == null) return;
         var event = data.optString("event", "");
+        if (event.equals("output")) return;
         var vmId = UUID.fromString(data.optString("vm_id", ""));
         var vmName = data.optString("vm_name", "");
         var stateStr = data.optString("state", "stopped");

--- a/app/src/main/java/cn/classfun/droidvm/ui/main/home/MainHomeFragment.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/main/home/MainHomeFragment.java
@@ -358,6 +358,8 @@ public final class MainHomeFragment extends MainBaseFragment
 
     @Override
     public void onDaemonEvent(JSONObject data) {
+        var inner = data.optJSONObject("data");
+        if (inner != null && "output".equals(inner.optString("event"))) return;
         refreshView();
     }
 


### PR DESCRIPTION
- MainHomeFragment.onDaemonEvent: ignore output events
- VMEventHandler.onDaemonEvent: short-circuit output before main-thread post
- VM stdout/stderr/uart bursts no longer trigger home summary refresh or onVMStateChanged dispatch, fixing main thread saturation during VM boot