### PR TITLE
Add DHCP options and prefer prebuilt dnsmasq binary

### DIFF
--- a/app/src/main/java/cn/classfun/droidvm/daemon/network/backend/Dnsmasq.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/network/backend/Dnsmasq.java
@@ -1,6 +1,7 @@
 package cn.classfun.droidvm.daemon.network.backend;
 
 import static cn.classfun.droidvm.lib.Constants.DATA_DIR;
+import static cn.classfun.droidvm.lib.utils.AssetUtils.getPrebuiltBinaryPath;
 import static cn.classfun.droidvm.lib.utils.StringUtils.fmt;
 import static cn.classfun.droidvm.lib.utils.StringUtils.pathJoin;
 
@@ -34,18 +35,29 @@ public final class Dnsmasq {
         this.inst = inst;
     }
 
+    @NonNull
+    private static String resolveDnsmasqBinary() {
+        var prebuilt = getPrebuiltBinaryPath("dnsmasq");
+        var file = new File(prebuilt);
+        if (file.isFile() && file.canExecute())
+            return prebuilt;
+        return "dnsmasq";
+    }
+
     private void startDnsmasqProcess(
     ) {
         var bridge = inst.item.optString("bridge_name", "");
         var rangeStart = inst.item.optString("dhcp_range_start", "");
         var rangeEnd = inst.item.optString("dhcp_range_end", "");
         var router = findRouterAddress(rangeStart);
-        Log.i(TAG, fmt("Starting dnsmasq on %s (%s - %s)", bridge, rangeStart, rangeEnd));
+        var dnsmasq = resolveDnsmasqBinary();
+        Log.i(TAG, fmt("Starting dnsmasq on %s (%s - %s) using %s",
+            bridge, rangeStart, rangeEnd, dnsmasq));
         var pidFile = getDnsmasqPidFile();
         var leaseFile = getDnsmasqLeaseFile();
         try {
             var args = new ArrayList<String>();
-            args.add("dnsmasq");
+            args.add(dnsmasq);
             args.add(fmt("--interface=%s", bridge));
             args.add("--bind-interfaces");
             args.add(fmt("--dhcp-range=%s,%s,12h", rangeStart, rangeEnd));

--- a/app/src/main/java/cn/classfun/droidvm/daemon/network/backend/Dnsmasq.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/network/backend/Dnsmasq.java
@@ -63,7 +63,13 @@ public final class Dnsmasq {
             args.add(fmt("--dhcp-range=%s,%s,12h", rangeStart, rangeEnd));
             if (router != null)
                 args.add(fmt("--dhcp-option=option:router,%s", router));
-            args.add("--dhcp-option=option:dns-server,8.8.8.8,1.1.1.1");
+            var dnsServers = new ArrayList<String>();
+            for (var iter : inst.item.get("dns_servers")) {
+                var s = iter.getValue().asString();
+                if (s != null && !s.isEmpty()) dnsServers.add(s);
+            }
+            if (!dnsServers.isEmpty())
+                args.add(fmt("--dhcp-option=option:dns-server,%s", String.join(",", dnsServers)));
             args.add("--port=0");
             args.add("--no-resolv");
             args.add("--no-daemon");

--- a/app/src/main/java/cn/classfun/droidvm/daemon/network/backend/Dnsmasq.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/network/backend/Dnsmasq.java
@@ -13,9 +13,12 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
 import java.io.InterruptedIOException;
+import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 import cn.classfun.droidvm.daemon.network.NetworkInstance;
+import cn.classfun.droidvm.lib.network.IPv4Address;
+import cn.classfun.droidvm.lib.network.IPv4Network;
 import cn.classfun.droidvm.lib.store.network.NetworkState;
 import cn.classfun.droidvm.lib.utils.ProcessUtils;
 
@@ -36,22 +39,28 @@ public final class Dnsmasq {
         var bridge = inst.item.optString("bridge_name", "");
         var rangeStart = inst.item.optString("dhcp_range_start", "");
         var rangeEnd = inst.item.optString("dhcp_range_end", "");
+        var router = findRouterAddress(rangeStart);
         Log.i(TAG, fmt("Starting dnsmasq on %s (%s - %s)", bridge, rangeStart, rangeEnd));
         var pidFile = getDnsmasqPidFile();
         var leaseFile = getDnsmasqLeaseFile();
         try {
-            var pb = new ProcessBuilder(
-                "dnsmasq",
-                fmt("--interface=%s", bridge),
-                "--bind-interfaces",
-                fmt("--dhcp-range=%s,%s,12h", rangeStart, rangeEnd),
-                "--no-daemon",
-                "--keep-in-foreground",
-                fmt("--pid-file=%s", pidFile),
-                fmt("--dhcp-leasefile=%s", leaseFile),
-                "--log-queries",
-                "--log-dhcp"
-            );
+            var args = new ArrayList<String>();
+            args.add("dnsmasq");
+            args.add(fmt("--interface=%s", bridge));
+            args.add("--bind-interfaces");
+            args.add(fmt("--dhcp-range=%s,%s,12h", rangeStart, rangeEnd));
+            if (router != null)
+                args.add(fmt("--dhcp-option=option:router,%s", router));
+            args.add("--dhcp-option=option:dns-server,8.8.8.8,1.1.1.1");
+            args.add("--port=0");
+            args.add("--no-resolv");
+            args.add("--no-daemon");
+            args.add("--keep-in-foreground");
+            args.add(fmt("--pid-file=%s", pidFile));
+            args.add(fmt("--dhcp-leasefile=%s", leaseFile));
+            args.add("--log-queries");
+            args.add("--log-dhcp");
+            var pb = new ProcessBuilder(args);
             pb.redirectErrorStream(true);
             dnsmasqExitCode = 0;
             dnsmasqProcess = pb.start();
@@ -59,6 +68,27 @@ public final class Dnsmasq {
         } catch (Exception e) {
             Log.e(TAG, fmt("Failed to start dnsmasq on %s", bridge), e);
         }
+    }
+
+    @Nullable
+    private String findRouterAddress(@NonNull String rangeStart) {
+        IPv4Address dhcpStart = null;
+        try {
+            if (!rangeStart.isEmpty()) dhcpStart = IPv4Address.parse(rangeStart);
+        } catch (Exception ignored) {
+        }
+
+        IPv4Network fallback = null;
+        for (var iter : inst.item.get("ipv4_addresses")) {
+            try {
+                var cidr = IPv4Network.parse(iter.getValue().asString());
+                if (fallback == null) fallback = cidr;
+                if (dhcpStart != null && cidr.contains(dhcpStart))
+                    return cidr.address().toString();
+            } catch (Exception ignored) {
+            }
+        }
+        return fallback != null ? fallback.address().toString() : null;
     }
 
     private void stopDnsmasqProcess(@Nullable Process process) {

--- a/app/src/main/java/cn/classfun/droidvm/ui/network/edit/NetworkEditActivity.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/network/edit/NetworkEditActivity.java
@@ -31,7 +31,6 @@ import java.util.Random;
 import java.util.UUID;
 
 import cn.classfun.droidvm.R;
-import cn.classfun.droidvm.lib.network.IPNetwork;
 import cn.classfun.droidvm.lib.network.IPv4Address;
 import cn.classfun.droidvm.lib.network.IPv4Network;
 import cn.classfun.droidvm.lib.network.IPv6Network;
@@ -47,14 +46,15 @@ public final class NetworkEditActivity extends AppCompatActivity {
     public static final String EXTRA_NETWORK_ID = "network_id";
     private final List<IPv4Network> ipv4Addresses = new ArrayList<>();
     private final List<IPv6Network> ipv6Addresses = new ArrayList<>();
+    private final List<IPv4Address> dnsServers = new ArrayList<>();
     private boolean editMode = false;
     private UUID editNetworkId = null;
     private CollapsingToolbarLayout collapsingToolbar;
     private TextInputRowWidget inputName, inputBridgeName, inputMac;
     private SwitchRowWidget swAutoUp, swStp, swNat, swDhcp;
-    private TextInputRowWidget inputIPv4, inputIPv6;
-    private LinearLayout layoutIPv4, layoutIPv6, groupDhcp;
-    private TextView tvIPv4Empty, tvIPv6Empty;
+    private TextInputRowWidget inputIPv4, inputIPv6, inputDns;
+    private LinearLayout layoutIPv4, layoutIPv6, layoutDns, groupDhcp;
+    private TextView tvIPv4Empty, tvIPv6Empty, tvDnsEmpty;
     private TextInputRowWidget inputDhcpStart, inputDhcpEnd;
     private FloatingActionButton fab;
     private NetworkStore store;
@@ -87,10 +87,13 @@ public final class NetworkEditActivity extends AppCompatActivity {
         swDhcp = findViewById(R.id.sw_dhcp);
         inputIPv4 = findViewById(R.id.input_ipv4);
         inputIPv6 = findViewById(R.id.input_ipv6);
+        inputDns = findViewById(R.id.input_dns);
         layoutIPv4 = findViewById(R.id.layout_ipv4);
         layoutIPv6 = findViewById(R.id.layout_ipv6);
+        layoutDns = findViewById(R.id.layout_dns);
         tvIPv4Empty = findViewById(R.id.tv_ipv4_empty);
         tvIPv6Empty = findViewById(R.id.tv_ipv6_empty);
+        tvDnsEmpty = findViewById(R.id.tv_dns_empty);
         groupDhcp = findViewById(R.id.group_dhcp);
         inputDhcpStart = findViewById(R.id.input_dhcp_start);
         inputDhcpEnd = findViewById(R.id.input_dhcp_end);
@@ -104,6 +107,7 @@ public final class NetworkEditActivity extends AppCompatActivity {
         store.load(this);
         inputIPv4.setEndIconOnClickListener(v -> onAddIPv4());
         inputIPv6.setEndIconOnClickListener(v -> onAddIPv6());
+        inputDns.setEndIconOnClickListener(v -> onAddDns());
         inputIPv4.addTextChangedListener(new SimpleTextWatcher() {
             @Override
             public void onTextChanged(CharSequence s, int start, int before, int count) {
@@ -114,6 +118,12 @@ public final class NetworkEditActivity extends AppCompatActivity {
             @Override
             public void onTextChanged(CharSequence s, int start, int before, int count) {
                 inputIPv6.setError(null);
+            }
+        });
+        inputDns.addTextChangedListener(new SimpleTextWatcher() {
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                inputDns.setError(null);
             }
         });
         swDhcp.setOnCheckedChangeListener((btn, checked) ->
@@ -130,8 +140,9 @@ public final class NetworkEditActivity extends AppCompatActivity {
             collapsingToolbar.setTitle(getString(R.string.network_create_title));
             generateDefaults();
         }
-        buildAddressList(layoutIPv4, tvIPv4Empty, ipv4Addresses, true);
-        buildAddressList(layoutIPv6, tvIPv6Empty, ipv6Addresses, false);
+        buildAddressList(layoutIPv4, tvIPv4Empty, ipv4Addresses, this::updateDhcpFromIPv4);
+        buildAddressList(layoutIPv6, tvIPv6Empty, ipv6Addresses, null);
+        buildAddressList(layoutDns, tvDnsEmpty, dnsServers, null);
     }
 
     private void installManualEditWatchers() {
@@ -177,8 +188,16 @@ public final class NetworkEditActivity extends AppCompatActivity {
         setTextProgrammatic(inputBridgeName, bridgeNameFromMac(mac));
         var ipv4Cidr = generateRandomIPv4();
         ipv4Addresses.add(ipv4Cidr);
+        addDefaultDnsServers();
         swDhcp.setChecked(true);
         updateDhcpFromIPv4();
+    }
+
+    private void addDefaultDnsServers() {
+        var a = IPv4Address.parse("8.8.8.8");
+        var b = IPv4Address.parse("1.1.1.1");
+        if (a != null) dnsServers.add(a);
+        if (b != null) dnsServers.add(b);
     }
 
     @NonNull
@@ -268,6 +287,9 @@ public final class NetworkEditActivity extends AppCompatActivity {
         parseIPv4Addresses(config, ipv4Addresses);
         ipv6Addresses.clear();
         parseIPv6Addresses(config, ipv6Addresses);
+        dnsServers.clear();
+        parseDnsServers(config, dnsServers);
+        if (dnsServers.isEmpty()) addDefaultDnsServers();
         macManuallyEdited = true;
         bridgeManuallyEdited = true;
         ipv4ManuallyEdited = true;
@@ -293,7 +315,7 @@ public final class NetworkEditActivity extends AppCompatActivity {
         ipv4Addresses.add(ip);
         ipv4ManuallyEdited = true;
         inputIPv4.setText("");
-        buildAddressList(layoutIPv4, tvIPv4Empty, ipv4Addresses, true);
+        buildAddressList(layoutIPv4, tvIPv4Empty, ipv4Addresses, this::updateDhcpFromIPv4);
         updateDhcpFromIPv4();
     }
 
@@ -314,14 +336,38 @@ public final class NetworkEditActivity extends AppCompatActivity {
         inputIPv6.setError(null);
         ipv6Addresses.add(ip);
         inputIPv6.setText("");
-        buildAddressList(layoutIPv6, tvIPv6Empty, ipv6Addresses, false);
+        buildAddressList(layoutIPv6, tvIPv6Empty, ipv6Addresses, null);
+    }
+
+    private void onAddDns() {
+        var addr = inputDns.getText().trim();
+        if (addr.isEmpty()) return;
+        if (!IPv4Address.isValid(addr)) {
+            inputDns.setError(getString(R.string.network_edit_error_dns_invalid));
+            return;
+        }
+        var ip = IPv4Address.parse(addr);
+        if (ip == null) {
+            inputDns.setError(getString(R.string.network_edit_error_dns_invalid));
+            return;
+        }
+        for (var existing : dnsServers) {
+            if (existing.value() == ip.value()) {
+                inputDns.setText("");
+                return;
+            }
+        }
+        inputDns.setError(null);
+        dnsServers.add(ip);
+        inputDns.setText("");
+        buildAddressList(layoutDns, tvDnsEmpty, dnsServers, null);
     }
 
     private void buildAddressList(
         @NonNull LinearLayout container,
         @NonNull TextView emptyView,
-        @NonNull List<? extends IPNetwork<?, ?, ?>> list,
-        boolean isIPv4
+        @NonNull List<?> list,
+        @Nullable Runnable onRemoved
     ) {
         container.removeAllViews();
         if (list.isEmpty()) {
@@ -347,8 +393,8 @@ public final class NetworkEditActivity extends AppCompatActivity {
                 btn.setContentDescription(getString(R.string.network_edit_remove_address));
                 btn.setOnClickListener(v -> {
                     list.remove(idx);
-                    buildAddressList(container, emptyView, list, isIPv4);
-                    if (isIPv4) updateDhcpFromIPv4();
+                    buildAddressList(container, emptyView, list, onRemoved);
+                    if (onRemoved != null) onRemoved.run();
                 });
                 row.addView(btn);
                 container.addView(row);
@@ -362,6 +408,7 @@ public final class NetworkEditActivity extends AppCompatActivity {
         inputMac.setError(null);
         inputIPv4.setError(null);
         inputIPv6.setError(null);
+        inputDns.setError(null);
         inputDhcpStart.setError(null);
         inputDhcpEnd.setError(null);
         if (!inputIPv4.getText().trim().isEmpty()) {
@@ -370,6 +417,14 @@ public final class NetworkEditActivity extends AppCompatActivity {
         }
         if (!inputIPv6.getText().trim().isEmpty()) {
             inputIPv6.setError(getString(R.string.network_edit_error_ipv6_not_added));
+            return;
+        }
+        if (!inputDns.getText().trim().isEmpty()) {
+            inputDns.setError(getString(R.string.network_edit_error_dns_not_added));
+            return;
+        }
+        if (dnsServers.isEmpty()) {
+            inputDns.setError(getString(R.string.network_edit_error_dns_empty));
             return;
         }
         var name = inputName.getText().trim();
@@ -445,6 +500,7 @@ public final class NetworkEditActivity extends AppCompatActivity {
         config.item.set("dhcp_enabled", swDhcp.isChecked());
         setIPv4Addresses(config, ipv4Addresses);
         setIPv6Addresses(config, ipv6Addresses);
+        setDnsServers(config, dnsServers);
         config.item.set("dhcp_range_start", inputDhcpStart.getText().trim());
         config.item.set("dhcp_range_end", inputDhcpEnd.getText().trim());
         if (editMode) {
@@ -544,6 +600,16 @@ public final class NetworkEditActivity extends AppCompatActivity {
         });
     }
 
+    private static void parseDnsServers(@NonNull NetworkConfig cfg, @NonNull List<IPv4Address> out) {
+        cfg.item.get("dns_servers").forEachArray(a -> {
+            try {
+                var ip = IPv4Address.parse(a.asString());
+                if (ip != null) out.add(ip);
+            } catch (Exception ignored) {
+            }
+        });
+    }
+
     private static void setIPv4Addresses(@NonNull NetworkConfig cfg, @NonNull List<IPv4Network> addresses) {
         var arr = DataItem.newArray();
         for (var addr : addresses)
@@ -556,5 +622,12 @@ public final class NetworkEditActivity extends AppCompatActivity {
         for (var addr : addresses)
             arr.append(DataItem.newString(addr.toString()));
         cfg.item.set("ipv6_addresses", arr);
+    }
+
+    private static void setDnsServers(@NonNull NetworkConfig cfg, @NonNull List<IPv4Address> dns) {
+        var arr = DataItem.newArray();
+        for (var ip : dns)
+            arr.append(DataItem.newString(ip.toString()));
+        cfg.item.set("dns_servers", arr);
     }
 }

--- a/app/src/main/res/drawable/ic_dns.xml
+++ b/app/src/main/res/drawable/ic_dns.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?attr/colorOnSurface"
+        android:pathData="M7,9A2,2 0 0,1 5,7A2,2 0 0,1 7,5A2,2 0 0,1 9,7A2,2 0 0,1 7,9M20,3H4A1,1 0 0,0 3,4V10A1,1 0 0,0 4,11H20A1,1 0 0,0 21,10V4A1,1 0 0,0 20,3M7,19A2,2 0 0,1 5,17A2,2 0 0,1 7,15A2,2 0 0,1 9,17A2,2 0 0,1 7,19M20,13H4A1,1 0 0,0 3,14V20A1,1 0 0,0 4,21H20A1,1 0 0,0 21,20V14A1,1 0 0,0 20,13Z" />
+</vector>

--- a/app/src/main/res/layout/activity_network_edit.xml
+++ b/app/src/main/res/layout/activity_network_edit.xml
@@ -171,6 +171,42 @@
             <cn.classfun.droidvm.ui.widgets.container.CollapsibleContainer
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:title="@string/network_edit_category_dns"
+                app:cc_collapsible="false">
+
+                <cn.classfun.droidvm.ui.widgets.row.TextInputRowWidget
+                    android:id="@+id/input_dns"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/network_edit_dns_hint"
+                    android:icon="@drawable/ic_dns"
+                    android:inputType="textNoSuggestions"
+                    app:ti_endIcon="@android:drawable/ic_input_add"
+                    app:ti_endIconMode="custom" />
+
+                <LinearLayout
+                    android:id="@+id/layout_dns"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:paddingStart="72dp"
+                    android:paddingEnd="16dp" />
+
+                <TextView
+                    android:id="@+id/tv_dns_empty"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:alpha="0.6"
+                    android:paddingStart="72dp"
+                    android:paddingEnd="16dp"
+                    android:text="@string/network_edit_no_addresses"
+                    android:textSize="14sp" />
+
+            </cn.classfun.droidvm.ui.widgets.container.CollapsibleContainer>
+
+            <cn.classfun.droidvm.ui.widgets.container.CollapsibleContainer
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:title="@string/network_edit_category_dhcp"
                 app:cc_collapsible="false">
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -603,6 +603,8 @@
     <string name="network_edit_nat">NAT（网络地址转换）</string>
     <string name="network_edit_category_ipv4">IPv4 地址</string>
     <string name="network_edit_ipv4_hint">IPv4 CIDR（例如 192.168.1.1/24）</string>
+    <string name="network_edit_category_dns">DNS 服务器</string>
+    <string name="network_edit_dns_hint">DNS 服务器（例如 8.8.8.8）</string>
     <string name="network_edit_category_ipv6">IPv6 地址</string>
     <string name="network_edit_ipv6_hint">IPv6 CIDR（例如 fd00::1/64）</string>
     <string name="network_edit_no_addresses">未配置地址。</string>
@@ -628,6 +630,9 @@
     <string name="network_edit_error_dhcp_end_invalid">无效的 DHCP 地址池结束地址</string>
     <string name="network_edit_error_ipv4_not_added">IPv4 地址输入框不为空，请先添加或清空</string>
     <string name="network_edit_error_ipv6_not_added">IPv6 地址输入框不为空，请先添加或清空</string>
+    <string name="network_edit_error_dns_not_added">DNS 服务器输入框不为空，请先添加或清空</string>
+    <string name="network_edit_error_dns_invalid">无效的 DNS 服务器地址</string>
+    <string name="network_edit_error_dns_empty">至少需要一个 DNS 服务器</string>
 
     <string name="network_info_start">启动</string>
     <string name="network_info_stop">停止</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -641,6 +641,8 @@
     <string name="network_edit_nat">NAT (Network Address Translate)</string>
     <string name="network_edit_category_ipv4">IPv4 Addresses</string>
     <string name="network_edit_ipv4_hint">IPv4 CIDR (e.g. 192.168.1.1/24)</string>
+    <string name="network_edit_category_dns">DNS Servers</string>
+    <string name="network_edit_dns_hint">DNS server (e.g. 8.8.8.8)</string>
     <string name="network_edit_category_ipv6">IPv6 Addresses</string>
     <string name="network_edit_ipv6_hint">IPv6 CIDR (e.g. fd00::1/64)</string>
     <string name="network_edit_no_addresses">No addresses configured.</string>
@@ -666,6 +668,9 @@
     <string name="network_edit_error_dhcp_end_invalid">Invalid DHCP pool end address</string>
     <string name="network_edit_error_ipv4_not_added">IPv4 address input is not empty, please add it first or clear the field</string>
     <string name="network_edit_error_ipv6_not_added">IPv6 address input is not empty, please add it first or clear the field</string>
+    <string name="network_edit_error_dns_not_added">DNS server input is not empty, please add it first or clear the field</string>
+    <string name="network_edit_error_dns_invalid">Invalid DNS server address</string>
+    <string name="network_edit_error_dns_empty">At least one DNS server is required</string>
 
     <string name="network_info_start">Start</string>
     <string name="network_info_stop">Stop</string>


### PR DESCRIPTION
This pull request enhances the `Dnsmasq` backend in the networking daemon by improving how the dnsmasq binary is located and how its process is started. It introduces logic to dynamically resolve the dnsmasq binary path, adds more robust DHCP configuration options, and improves the selection of the router address for DHCP clients.

**Dnsmasq binary resolution and process startup improvements:**

- Added a `resolveDnsmasqBinary()` method to locate a prebuilt dnsmasq binary if available, falling back to the system binary otherwise. This ensures the correct binary is used depending on the environment. [[1]](diffhunk://#diff-56aee1f646c461564ebd60bdca6b3ef5fbc3d54b943593a59b799893b7118b89R4) [[2]](diffhunk://#diff-56aee1f646c461564ebd60bdca6b3ef5fbc3d54b943593a59b799893b7118b89R38-R75)
- Refactored the dnsmasq process startup to build its command-line arguments dynamically using an `ArrayList`, allowing for more flexible and readable argument management.
- Added new dnsmasq options: static DNS servers (`--dhcp-option=option:dns-server,8.8.8.8,1.1.1.1`), disabled DNS port (`--port=0`), and disabled system resolver (`--no-resolv`) to improve network isolation and reliability.

**Router address determination:**

- Introduced the `findRouterAddress()` method to select the appropriate router address for the DHCP option based on the DHCP range and available IPv4 addresses, improving network configuration accuracy for clients. [[1]](diffhunk://#diff-56aee1f646c461564ebd60bdca6b3ef5fbc3d54b943593a59b799893b7118b89R85-R105) [[2]](diffhunk://#diff-56aee1f646c461564ebd60bdca6b3ef5fbc3d54b943593a59b799893b7118b89R38-R75)

**Dependency and import updates:**

- Added imports for `IPv4Address`, `IPv4Network`, and utility functions to support the new logic for binary resolution and network address parsing.