### PR TITLE
Implement comprehensive IP-based port forwarding management

### DIFF
--- a/app/src/main/java/cn/classfun/droidvm/daemon/ipc/vm/PortForwardListHandler.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/ipc/vm/PortForwardListHandler.java
@@ -1,0 +1,37 @@
+package cn.classfun.droidvm.daemon.ipc.vm;
+
+import static cn.classfun.droidvm.lib.utils.StringUtils.fmt;
+
+import androidx.annotation.NonNull;
+
+import com.google.auto.service.AutoService;
+
+import org.json.JSONObject;
+
+import cn.classfun.droidvm.daemon.server.ClientRequest;
+import cn.classfun.droidvm.daemon.server.RequestException;
+import cn.classfun.droidvm.daemon.server.RequestHandler;
+
+@AutoService(RequestHandler.class)
+public final class PortForwardListHandler extends RequestHandler {
+    @NonNull
+    @Override
+    public String getName() {
+        return "vm_port_forward_list";
+    }
+
+    @Override
+    public void handle(@NonNull ClientRequest request) throws Exception {
+        var params = request.getParams();
+        var id = params.optString("vm_id", "");
+        if (id.isEmpty())
+            throw new RequestException("missing vm_id");
+        var vm = request.getContext().getVMs().findById(id);
+        if (vm == null)
+            throw new RequestException(fmt("VM %s not found", id));
+        var data = new JSONObject();
+        data.put("configured", vm.getConfiguredPortForwards());
+        data.put("active", vm.getActivePortForwards());
+        request.res().put("data", data);
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/daemon/ipc/vm/PortForwardSetHandler.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/ipc/vm/PortForwardSetHandler.java
@@ -1,0 +1,41 @@
+package cn.classfun.droidvm.daemon.ipc.vm;
+
+import static cn.classfun.droidvm.lib.utils.StringUtils.fmt;
+
+import androidx.annotation.NonNull;
+
+import com.google.auto.service.AutoService;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import cn.classfun.droidvm.daemon.server.ClientRequest;
+import cn.classfun.droidvm.daemon.server.RequestException;
+import cn.classfun.droidvm.daemon.server.RequestHandler;
+
+/** IPC: hot-applies {@code rules} to a running VM ({@code vm_id}); the frontend owns persistence. */
+@AutoService(RequestHandler.class)
+public final class PortForwardSetHandler extends RequestHandler {
+    @NonNull
+    @Override
+    public String getName() {
+        return "vm_port_forward_set";
+    }
+
+    @Override
+    public void handle(@NonNull ClientRequest request) throws Exception {
+        var params = request.getParams();
+        var id = params.optString("vm_id", "");
+        if (id.isEmpty())
+            throw new RequestException("missing vm_id");
+        var vm = request.getContext().getVMs().findById(id);
+        if (vm == null)
+            throw new RequestException(fmt("VM %s not found", id));
+        var rules = params.optJSONArray("rules");
+        if (rules == null) rules = new JSONArray();
+        vm.applyPortForwards(rules);
+        var data = new JSONObject();
+        data.put("active", vm.getActivePortForwards());
+        request.res().put("data", data);
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/daemon/network/backend/FirewallHelper.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/network/backend/FirewallHelper.java
@@ -1,5 +1,8 @@
 package cn.classfun.droidvm.daemon.network.backend;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import cn.classfun.droidvm.daemon.network.NetworkInstance;
 
 @SuppressWarnings({"BooleanMethodIsAlwaysInverted", "unused", "UnusedReturnValue"})
@@ -12,4 +15,12 @@ public abstract class FirewallHelper {
     public abstract void initNetwork(NetworkInstance inst);
 
     public abstract void deinitNetwork(NetworkInstance inst);
+
+    public abstract boolean applyForward(
+        @NonNull String bridge, @NonNull String guestIp, @NonNull String protocol,
+        @Nullable String hostIp, int hostPort, int guestPort);
+
+    public abstract boolean removeForward(
+        @NonNull String bridge, @NonNull String guestIp, @NonNull String protocol,
+        @Nullable String hostIp, int hostPort, int guestPort);
 }

--- a/app/src/main/java/cn/classfun/droidvm/daemon/network/backend/iptables/ChainInfo.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/network/backend/iptables/ChainInfo.java
@@ -57,6 +57,18 @@ final class ChainInfo {
         return backend.iptables(cmd.toArray(new String[0]));
     }
 
+    public boolean insert(@NonNull String... args) {
+        var cmd = new ArrayList<String>();
+        cmd.add("iptables");
+        cmd.add("-t");
+        cmd.add(table);
+        cmd.add("-I");
+        cmd.add(chain);
+        cmd.add("1");
+        cmd.addAll(Arrays.asList(args));
+        return backend.iptables(cmd.toArray(new String[0]));
+    }
+
     @SuppressWarnings("unused")
     public boolean delete(@NonNull String... args) {
         var cmd = new ArrayList<String>();

--- a/app/src/main/java/cn/classfun/droidvm/daemon/network/backend/iptables/IptablesBackend.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/network/backend/iptables/IptablesBackend.java
@@ -1,8 +1,11 @@
 package cn.classfun.droidvm.daemon.network.backend.iptables;
 
+import static cn.classfun.droidvm.lib.utils.StringUtils.fmt;
+
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -106,6 +109,75 @@ public final class IptablesBackend extends FirewallHelper {
     public void deinitNetwork(NetworkInstance inst) {
         var net = new IptablesNetworkInstance(this, inst);
         net.deinit();
+    }
+
+    @Override
+    public boolean applyForward(
+        @NonNull String bridge, @NonNull String guestIp, @NonNull String protocol,
+        @Nullable String hostIp, int hostPort, int guestPort
+    ) {
+        var pre = new ChainInfo(this, "nat", null, fmt("droidvm_pre_%s", bridge));
+        var fwd = new ChainInfo(this, "filter", null, fmt("droidvm_fwd_%s", bridge));
+        boolean ok = pre.append(dnatSpec(protocol, hostIp, hostPort, guestIp, guestPort));
+        ok &= fwd.insert(fwdSpec(bridge, guestIp, protocol, guestPort));
+        Log.i(TAG, fmt("Apply forward %s %s:%d -> %s:%d on %s (ok=%b)",
+            protocol, isSpecificHost(hostIp) ? hostIp : "*",
+            hostPort, guestIp, guestPort, bridge, ok));
+        return ok;
+    }
+
+    @Override
+    public boolean removeForward(
+        @NonNull String bridge, @NonNull String guestIp, @NonNull String protocol,
+        @Nullable String hostIp, int hostPort, int guestPort
+    ) {
+        var pre = new ChainInfo(this, "nat", null, fmt("droidvm_pre_%s", bridge));
+        var fwd = new ChainInfo(this, "filter", null, fmt("droidvm_fwd_%s", bridge));
+        boolean ok = pre.delete(dnatSpec(protocol, hostIp, hostPort, guestIp, guestPort));
+        ok &= fwd.delete(fwdSpec(bridge, guestIp, protocol, guestPort));
+        Log.i(TAG, fmt("Remove forward %s %s:%d -> %s:%d on %s (ok=%b)",
+            protocol, isSpecificHost(hostIp) ? hostIp : "*",
+            hostPort, guestIp, guestPort, bridge, ok));
+        return ok;
+    }
+
+    @NonNull
+    private static String[] dnatSpec(
+        @NonNull String protocol, @Nullable String hostIp, int hostPort,
+        @NonNull String guestIp, int guestPort
+    ) {
+        var spec = new ArrayList<String>();
+        spec.add("-p");
+        spec.add(protocol);
+        if (isSpecificHost(hostIp)) {
+            spec.add("-d");
+            spec.add(hostIp);
+        }
+        spec.add("--dport");
+        spec.add(String.valueOf(hostPort));
+        spec.add("-j");
+        spec.add("DNAT");
+        spec.add("--to-destination");
+        spec.add(fmt("%s:%d", guestIp, guestPort));
+        return spec.toArray(new String[0]);
+    }
+
+    @NonNull
+    private static String[] fwdSpec(
+        @NonNull String bridge, @NonNull String guestIp,
+        @NonNull String protocol, int guestPort
+    ) {
+        return new String[]{
+            "-o", bridge, "-d", guestIp, "-p", protocol,
+            "--dport", String.valueOf(guestPort), "-j", "ACCEPT"
+        };
+    }
+
+    /** A wildcard host_ip (empty / 0.0.0.0[/0] / ::[/0]) must omit -d, or the DNAT never matches. */
+    private static boolean isSpecificHost(@Nullable String hostIp) {
+        return hostIp != null && !hostIp.isEmpty()
+            && !hostIp.equals("0.0.0.0") && !hostIp.equals("0.0.0.0/0")
+            && !hostIp.equals("::") && !hostIp.equals("::/0");
     }
 
     private boolean enableIpForward() {

--- a/app/src/main/java/cn/classfun/droidvm/daemon/vm/VMInstance.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/vm/VMInstance.java
@@ -404,6 +404,17 @@ public final class VMInstance extends VMConfig {
         return pf != null ? pf.snapshotApplied() : new JSONArray();
     }
 
+    /**
+     * 运行时热更新端口转发规则：更新内存配置后即时同步到 iptables（增删 DNAT 规则）。
+     * 仅作用于 daemon 运行态；配置的持久化由前端负责（写入共享的 vms.json），
+     * 下次启动时前端会通过 vm_modify 重新下发完整配置。
+     */
+    public void applyPortForwards(@NonNull JSONArray rules) {
+        item.set("port_forwards", rules);
+        var pf = portForwarder;
+        if (pf != null) pf.sync();
+    }
+
     private void startReaderThread(@NonNull String vmId, @NonNull ConsoleStream stream) {
         var streamName = stream.getName();
         if (!stream.isReadable()) return;

--- a/app/src/main/java/cn/classfun/droidvm/daemon/vm/VMInstance.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/vm/VMInstance.java
@@ -42,6 +42,7 @@ public final class VMInstance extends VMConfig {
     private BackendBase backend;
     private VMBackendInstance backendInstance;
     private Thread workerThread;
+    private VMPortForwarder portForwarder;
     private final VMInstanceStore store;
 
     public interface VMEventCallback {
@@ -321,6 +322,7 @@ public final class VMInstance extends VMConfig {
                 startReaderThread(vmId, stream);
         }
         setState(VMState.RUNNING);
+        startPortForwarding();
         int code = process.waitFor();
         for (var stream : inst.streams.values()) {
             var reader = stream.getReaderThread();
@@ -345,6 +347,7 @@ public final class VMInstance extends VMConfig {
         } else {
             Log.i(TAG, fmt("VM %s exited with code %d", getName(), code));
         }
+        stopPortForwarding();
         cleanupTap();
         inst.cleanup();
         setState(VMState.STOPPED);
@@ -362,6 +365,43 @@ public final class VMInstance extends VMConfig {
             bridge.removeInterface(tapVal);
             bridge.deleteTap(tapVal);
         }
+    }
+
+    private void startPortForwarding() {
+        try {
+            portForwarder = new VMPortForwarder(this, store.networkStore);
+            portForwarder.start();
+        } catch (Exception e) {
+            Log.w(TAG, fmt("Failed to start port forwarding for VM %s", getName()), e);
+        }
+    }
+
+    private void stopPortForwarding() {
+        if (portForwarder == null) return;
+        try {
+            portForwarder.stop();
+        } catch (Exception e) {
+            Log.w(TAG, fmt("Failed to stop port forwarding for VM %s", getName()), e);
+        }
+        portForwarder = null;
+    }
+
+    @NonNull
+    public JSONArray getConfiguredPortForwards() throws JSONException {
+        var arr = new JSONArray();
+        var pf = item.opt("port_forwards", null);
+        if (pf != null && pf.is(DataItem.Type.ARRAY))
+            for (var iter : pf) {
+                var r = iter.getValue();
+                if (r.is(DataItem.Type.OBJECT)) arr.put(r.toJson());
+            }
+        return arr;
+    }
+
+    @NonNull
+    public JSONArray getActivePortForwards() {
+        var pf = portForwarder;
+        return pf != null ? pf.snapshotApplied() : new JSONArray();
     }
 
     private void startReaderThread(@NonNull String vmId, @NonNull ConsoleStream stream) {

--- a/app/src/main/java/cn/classfun/droidvm/daemon/vm/VMInstance.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/vm/VMInstance.java
@@ -42,7 +42,7 @@ public final class VMInstance extends VMConfig {
     private BackendBase backend;
     private VMBackendInstance backendInstance;
     private Thread workerThread;
-    private VMPortForwarder portForwarder;
+    private volatile VMPortForwarder portForwarder;
     private final VMInstanceStore store;
 
     public interface VMEventCallback {
@@ -404,11 +404,7 @@ public final class VMInstance extends VMConfig {
         return pf != null ? pf.snapshotApplied() : new JSONArray();
     }
 
-    /**
-     * 运行时热更新端口转发规则：更新内存配置后即时同步到 iptables（增删 DNAT 规则）。
-     * 仅作用于 daemon 运行态；配置的持久化由前端负责（写入共享的 vms.json），
-     * 下次启动时前端会通过 vm_modify 重新下发完整配置。
-     */
+    /** Runtime-only hot-update of DNAT rules; the frontend owns persistence (re-pushed via vm_modify on next start). */
     public void applyPortForwards(@NonNull JSONArray rules) {
         item.set("port_forwards", rules);
         var pf = portForwarder;

--- a/app/src/main/java/cn/classfun/droidvm/daemon/vm/VMPortForwarder.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/vm/VMPortForwarder.java
@@ -102,6 +102,90 @@ final class VMPortForwarder {
         return arr;
     }
 
+    /**
+     * 运行时热同步当前配置：
+     * <ul>
+     *   <li>已在转发（VM 启动时已有规则）→ {@link #reapply()} 做增量 diff；</li>
+     *   <li>此前因无规则未启动 → {@link #start()} 按新配置启动轮询应用。</li>
+     * </ul>
+     * 供 {@link VMInstance#applyPortForwards} 在运行时改规则后调用。
+     */
+    synchronized void sync() {
+        if (running) reapply();
+        else start();
+    }
+
+    /**
+     * 运行时热更新：基于 VM 当前 {@code port_forwards} 配置对已应用规则做增量 diff——
+     * 移除不再需要的、应用新增的。仅在 VM 运行（已 {@link #start()}）时有效。
+     * 新增规则要求 guest IP 当前可解析（运行中 VM 一般已联网，故可解析）。
+     */
+    private synchronized void reapply() {
+        if (!running || networkStore == null) return;
+        var rules = parseRules();
+        // 锁外解析目标，避免持 applied 锁期间做 DHCP/邻居表查询
+        var desired = new ArrayList<Applied>();
+        for (var rule : rules) {
+            var target = resolveTarget(rule);
+            if (target == null) {
+                Log.w(TAG, fmt("VM %s: reapply skipped unresolved %s :%d (guest IP not ready)",
+                    vm.getName(), rule.protocol, rule.hostPort));
+                continue;
+            }
+            desired.add(new Applied(target.bridge, target.ip, rule.protocol,
+                rule.hostIp, rule.hostPort, rule.guestPort));
+        }
+        synchronized (applied) {
+            applied.removeIf(a -> {
+                boolean keep = false;
+                for (var d : desired)
+                    if (sameForward(a, d)) {
+                        keep = true;
+                        break;
+                    }
+                if (!keep) {
+                    networkStore.firewall.removeForward(
+                        a.bridge, a.guestIp, a.protocol, a.hostIp, a.hostPort, a.guestPort);
+                    Log.i(TAG, fmt("VM %s: reapply removed %s :%d -> %s:%d",
+                        vm.getName(), a.protocol, a.hostPort, a.guestIp, a.guestPort));
+                }
+                return !keep;
+            });
+            for (var d : desired) {
+                boolean exists = false;
+                for (var a : applied)
+                    if (sameForward(a, d)) {
+                        exists = true;
+                        break;
+                    }
+                if (exists) continue;
+                boolean ok = networkStore.firewall.applyForward(
+                    d.bridge, d.guestIp, d.protocol, d.hostIp, d.hostPort, d.guestPort);
+                if (ok) {
+                    applied.add(d);
+                    Log.i(TAG, fmt("VM %s: reapply added %s :%d -> %s:%d",
+                        vm.getName(), d.protocol, d.hostPort, d.guestIp, d.guestPort));
+                } else {
+                    Log.w(TAG, fmt("VM %s: reapply failed to apply %s :%d",
+                        vm.getName(), d.protocol, d.hostPort));
+                }
+            }
+        }
+    }
+
+    private static boolean sameForward(@NonNull Applied a, @NonNull Applied b) {
+        return a.protocol.equals(b.protocol)
+            && a.hostPort == b.hostPort
+            && a.guestPort == b.guestPort
+            && eq(a.hostIp, b.hostIp)
+            && eq(a.guestIp, b.guestIp)
+            && eq(a.bridge, b.bridge);
+    }
+
+    private static boolean eq(@Nullable String a, @Nullable String b) {
+        return a == null ? b == null : a.equals(b);
+    }
+
     private void loop() {
         var rules = parseRules();
         if (rules.isEmpty()) return;

--- a/app/src/main/java/cn/classfun/droidvm/daemon/vm/VMPortForwarder.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/vm/VMPortForwarder.java
@@ -1,7 +1,6 @@
 package cn.classfun.droidvm.daemon.vm;
 
 import static cn.classfun.droidvm.lib.utils.StringUtils.fmt;
-import static cn.classfun.droidvm.lib.utils.ThreadUtils.threadSleep;
 
 import android.util.Log;
 
@@ -23,20 +22,8 @@ import cn.classfun.droidvm.lib.store.base.DataItem;
 import cn.classfun.droidvm.lib.store.vm.VMState;
 
 /**
- * 管理单个 VM 的端口转发（host -> guest）iptables DNAT 规则。
- * VM 进入 RUNNING 后启动：轮询 DHCP 租约/邻居表，按网卡 MAC 解析 guest IP，
- * 然后下发规则；VM 退出时撤销全部已下发的规则。
- *
- * <p>规则来源于 VM 配置的 {@code port_forwards} 数组，每项字段：
- * <ul>
- *   <li>{@code protocol}: tcp | udp（默认 tcp）</li>
- *   <li>{@code host_port}: 宿主机监听端口（必填）</li>
- *   <li>{@code guest_port}: guest 目标端口（默认与 host_port 相同）</li>
- *   <li>{@code host_ip}: 可选，仅转发发往该宿主地址的流量；留空=全部</li>
- *   <li>{@code network_id}: 可选，多网卡时指定走哪个网卡；留空=首个网卡</li>
- *   <li>{@code guest_ip}: 可选，手动指定 guest IP，跳过自动发现</li>
- *   <li>{@code enabled}: 可选，默认 true</li>
- * </ul>
+ * Installs host -> guest iptables DNAT rules for one VM's {@code port_forwards}, resolving the
+ * guest IP from DHCP leases / the neighbor table while the VM is RUNNING.
  */
 final class VMPortForwarder {
     private static final String TAG = "VMPortForwarder";
@@ -74,6 +61,7 @@ final class VMPortForwarder {
 
     synchronized void stop() {
         running = false;
+        notifyAll();
         var t = thread;
         if (t != null) {
             t.interrupt();
@@ -102,34 +90,30 @@ final class VMPortForwarder {
         return arr;
     }
 
-    /**
-     * 运行时热同步当前配置：
-     * <ul>
-     *   <li>已在转发（VM 启动时已有规则）→ {@link #reapply()} 做增量 diff；</li>
-     *   <li>此前因无规则未启动 → {@link #start()} 按新配置启动轮询应用。</li>
-     * </ul>
-     * 供 {@link VMInstance#applyPortForwards} 在运行时改规则后调用。
-     */
+    /** Wakes the poll thread (or starts it) so reconcile always runs on that single thread. */
     synchronized void sync() {
-        if (running) reapply();
+        if (running) notifyAll();
         else start();
     }
 
     /**
-     * 运行时热更新：基于 VM 当前 {@code port_forwards} 配置对已应用规则做增量 diff——
-     * 移除不再需要的、应用新增的。仅在 VM 运行（已 {@link #start()}）时有效。
-     * 新增规则要求 guest IP 当前可解析（运行中 VM 一般已联网，故可解析）。
+     * Incrementally reconciles installed rules to the current config. Poll-thread only and the
+     * sole writer of {@link #applied} (besides {@link #stop()}). A still-configured binding whose
+     * guest IP is momentarily unresolvable keeps its old entry and is switched atomically once
+     * resolvable, so hot-editing guest_ip/NIC never drops a working forward.
+     *
+     * @return whether any rule is still configured-but-unresolvable (keep polling).
      */
-    private synchronized void reapply() {
-        if (!running || networkStore == null) return;
+    private boolean reconcile() {
+        if (!running || networkStore == null) return false;
         var rules = parseRules();
-        // 锁外解析目标，避免持 applied 锁期间做 DHCP/邻居表查询
+        // Resolve outside the applied lock; DHCP / neighbor lookups are slow.
         var desired = new ArrayList<Applied>();
+        boolean hasUnresolved = false;
         for (var rule : rules) {
             var target = resolveTarget(rule);
             if (target == null) {
-                Log.w(TAG, fmt("VM %s: reapply skipped unresolved %s :%d (guest IP not ready)",
-                    vm.getName(), rule.protocol, rule.hostPort));
+                hasUnresolved = true;
                 continue;
             }
             desired.add(new Applied(target.bridge, target.ip, rule.protocol,
@@ -137,19 +121,14 @@ final class VMPortForwarder {
         }
         synchronized (applied) {
             applied.removeIf(a -> {
-                boolean keep = false;
                 for (var d : desired)
-                    if (sameForward(a, d)) {
-                        keep = true;
-                        break;
-                    }
-                if (!keep) {
-                    networkStore.firewall.removeForward(
-                        a.bridge, a.guestIp, a.protocol, a.hostIp, a.hostPort, a.guestPort);
-                    Log.i(TAG, fmt("VM %s: reapply removed %s :%d -> %s:%d",
-                        vm.getName(), a.protocol, a.hostPort, a.guestIp, a.guestPort));
-                }
-                return !keep;
+                    if (sameForward(a, d)) return false;
+                if (hostBindingConfigured(a, rules)) return false;
+                networkStore.firewall.removeForward(
+                    a.bridge, a.guestIp, a.protocol, a.hostIp, a.hostPort, a.guestPort);
+                Log.i(TAG, fmt("VM %s: removed forward %s :%d -> %s:%d",
+                    vm.getName(), a.protocol, a.hostPort, a.guestIp, a.guestPort));
+                return true;
             });
             for (var d : desired) {
                 boolean exists = false;
@@ -159,18 +138,27 @@ final class VMPortForwarder {
                         break;
                     }
                 if (exists) continue;
+                applied.removeIf(a -> {
+                    if (!sameHostBinding(a, d)) return false;
+                    networkStore.firewall.removeForward(
+                        a.bridge, a.guestIp, a.protocol, a.hostIp, a.hostPort, a.guestPort);
+                    Log.i(TAG, fmt("VM %s: switched forward %s :%d off %s:%d",
+                        vm.getName(), a.protocol, a.hostPort, a.guestIp, a.guestPort));
+                    return true;
+                });
                 boolean ok = networkStore.firewall.applyForward(
                     d.bridge, d.guestIp, d.protocol, d.hostIp, d.hostPort, d.guestPort);
                 if (ok) {
                     applied.add(d);
-                    Log.i(TAG, fmt("VM %s: reapply added %s :%d -> %s:%d",
+                    Log.i(TAG, fmt("VM %s: forward %s :%d -> %s:%d",
                         vm.getName(), d.protocol, d.hostPort, d.guestIp, d.guestPort));
                 } else {
-                    Log.w(TAG, fmt("VM %s: reapply failed to apply %s :%d",
+                    Log.w(TAG, fmt("VM %s: failed to apply forward %s :%d",
                         vm.getName(), d.protocol, d.hostPort));
                 }
             }
         }
+        return hasUnresolved;
     }
 
     private static boolean sameForward(@NonNull Applied a, @NonNull Applied b) {
@@ -182,54 +170,44 @@ final class VMPortForwarder {
             && eq(a.bridge, b.bridge);
     }
 
+    private static boolean sameHostBinding(@NonNull Applied a, @NonNull Applied b) {
+        return a.protocol.equals(b.protocol) && a.hostPort == b.hostPort && eq(a.hostIp, b.hostIp);
+    }
+
+    private static boolean hostBindingConfigured(@NonNull Applied a, @NonNull List<Rule> rules) {
+        for (var r : rules)
+            if (a.protocol.equals(r.protocol) && a.hostPort == r.hostPort && eq(a.hostIp, r.hostIp))
+                return true;
+        return false;
+    }
+
     private static boolean eq(@Nullable String a, @Nullable String b) {
         return a == null ? b == null : a.equals(b);
     }
 
+    /** Reconcile/wait loop; stays alive the whole RUNNING period so late rule changes are still reconciled. */
     private void loop() {
-        var rules = parseRules();
-        if (rules.isEmpty()) return;
-        int attempts = 0;
-        while (running && vm.getState() == VMState.RUNNING) {
-            boolean allDone = true;
-            for (var rule : rules) {
-                if (rule.done) continue;
-                if (!running) return;
-                var target = resolveTarget(rule);
-                if (target == null) {
-                    allDone = false;
-                    continue;
-                }
-                boolean ok = networkStore.firewall.applyForward(
-                    target.bridge, target.ip, rule.protocol,
-                    rule.hostIp, rule.hostPort, rule.guestPort);
-                rule.done = true;
-                if (!ok) {
-                    Log.w(TAG, fmt("VM %s: failed to apply forward %s :%d -> %s:%d",
-                        vm.getName(), rule.protocol, rule.hostPort, target.ip, rule.guestPort));
-                    continue;
-                }
-                // 与 stop()/removeAll() 通过 applied 锁互斥，避免 stop 后仍残留规则
-                synchronized (applied) {
-                    if (!running) {
-                        networkStore.firewall.removeForward(
-                            target.bridge, target.ip, rule.protocol,
-                            rule.hostIp, rule.hostPort, rule.guestPort);
+        try {
+            int attempts = 0;
+            synchronized (this) {
+                while (running && vm.getState() == VMState.RUNNING) {
+                    boolean hasUnresolved = reconcile();
+                    if (!running) break;
+                    if (hasUnresolved && attempts < RESOLVE_MAX_ATTEMPTS) {
+                        attempts++;
+                        wait(RESOLVE_INTERVAL_MS);
                     } else {
-                        applied.add(new Applied(target.bridge, target.ip, rule.protocol,
-                            rule.hostIp, rule.hostPort, rule.guestPort));
-                        Log.i(TAG, fmt("VM %s: forward %s :%d -> %s:%d",
-                            vm.getName(), rule.protocol, rule.hostPort, target.ip, rule.guestPort));
+                        if (hasUnresolved)
+                            Log.w(TAG, fmt("VM %s: gave up auto-resolving guest IP for some port"
+                                    + " forwards after %d attempts; will retry on next config change",
+                                vm.getName(), attempts));
+                        attempts = 0;
+                        wait();
                     }
                 }
             }
-            if (allDone) break;
-            if (++attempts >= RESOLVE_MAX_ATTEMPTS) {
-                Log.w(TAG, fmt("VM %s: gave up resolving guest IP for some port forwards after %d attempts",
-                    vm.getName(), attempts));
-                break;
-            }
-            threadSleep(RESOLVE_INTERVAL_MS);
+        } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
         }
     }
 
@@ -263,7 +241,6 @@ final class VMPortForwarder {
             if (guestPort <= 0 || guestPort > 65535) guestPort = hostPort;
             var hostIp = r.optString("host_ip", "");
             if (hostIp == null) hostIp = "";
-            // 同一 VM 内按 (protocol, host_ip, host_port) 去重，避免重复 DNAT
             var key = fmt("%s|%s|%d", protocol, hostIp, hostPort);
             if (!seen.add(key)) {
                 Log.w(TAG, fmt("VM %s: duplicate port forward %s, skipping", vm.getName(), key));
@@ -304,10 +281,8 @@ final class VMPortForwarder {
     private String resolveGuestIpByMac(
         @NonNull NetworkInstance netInst, @NonNull String bridge, @NonNull String mac) {
         var macLower = mac.toLowerCase(Locale.ROOT);
-        // 1. 优先用 dnsmasq DHCP 租约
         var ip = matchMac(networkStore.backend.listDhcpLeases(bridge), macLower, "ip", "mac");
         if (ip != null) return ip;
-        // 2. 回退到 ARP 邻居表（适用于静态 IP 且已通信过的 guest）
         return matchMac(netInst.listNeighbors(), macLower, "dst", "lladdr");
     }
 
@@ -370,7 +345,6 @@ final class VMPortForwarder {
         int guestPort;
         String networkId;
         String fixedGuestIp;
-        boolean done = false;
     }
 
     private static final class Target {

--- a/app/src/main/java/cn/classfun/droidvm/daemon/vm/VMPortForwarder.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/vm/VMPortForwarder.java
@@ -1,0 +1,301 @@
+package cn.classfun.droidvm.daemon.vm;
+
+import static cn.classfun.droidvm.lib.utils.StringUtils.fmt;
+import static cn.classfun.droidvm.lib.utils.ThreadUtils.threadSleep;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+
+import cn.classfun.droidvm.daemon.network.NetworkInstance;
+import cn.classfun.droidvm.daemon.network.NetworkInstanceStore;
+import cn.classfun.droidvm.lib.store.base.DataItem;
+import cn.classfun.droidvm.lib.store.vm.VMState;
+
+/**
+ * 管理单个 VM 的端口转发（host -> guest）iptables DNAT 规则。
+ * VM 进入 RUNNING 后启动：轮询 DHCP 租约/邻居表，按网卡 MAC 解析 guest IP，
+ * 然后下发规则；VM 退出时撤销全部已下发的规则。
+ *
+ * <p>规则来源于 VM 配置的 {@code port_forwards} 数组，每项字段：
+ * <ul>
+ *   <li>{@code protocol}: tcp | udp（默认 tcp）</li>
+ *   <li>{@code host_port}: 宿主机监听端口（必填）</li>
+ *   <li>{@code guest_port}: guest 目标端口（默认与 host_port 相同）</li>
+ *   <li>{@code host_ip}: 可选，仅转发发往该宿主地址的流量；留空=全部</li>
+ *   <li>{@code network_id}: 可选，多网卡时指定走哪个网卡；留空=首个网卡</li>
+ *   <li>{@code guest_ip}: 可选，手动指定 guest IP，跳过自动发现</li>
+ *   <li>{@code enabled}: 可选，默认 true</li>
+ * </ul>
+ */
+final class VMPortForwarder {
+    private static final String TAG = "VMPortForwarder";
+    private static final int RESOLVE_MAX_ATTEMPTS = 30;
+    private static final long RESOLVE_INTERVAL_MS = 1000L;
+
+    private final VMInstance vm;
+    private final NetworkInstanceStore networkStore;
+    private final List<Applied> applied = new ArrayList<>();
+    private volatile boolean running = false;
+    private Thread thread;
+
+    VMPortForwarder(@NonNull VMInstance vm, @Nullable NetworkInstanceStore networkStore) {
+        this.vm = vm;
+        this.networkStore = networkStore;
+    }
+
+    boolean hasRules() {
+        var pf = vm.item.opt("port_forwards", null);
+        return pf != null && !pf.isEmpty();
+    }
+
+    synchronized void start() {
+        if (running) return;
+        if (!hasRules()) return;
+        if (networkStore == null) {
+            Log.w(TAG, fmt("VM %s has port forwards but no network store", vm.getName()));
+            return;
+        }
+        running = true;
+        thread = new Thread(this::loop, fmt("PF-%s", vm.getId()));
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    synchronized void stop() {
+        running = false;
+        var t = thread;
+        if (t != null) {
+            t.interrupt();
+            thread = null;
+        }
+        removeAll();
+    }
+
+    @NonNull
+    JSONArray snapshotApplied() {
+        var arr = new JSONArray();
+        synchronized (applied) {
+            for (var a : applied) {
+                try {
+                    var o = new JSONObject();
+                    o.put("protocol", a.protocol);
+                    o.put("host_ip", a.hostIp == null ? "" : a.hostIp);
+                    o.put("host_port", a.hostPort);
+                    o.put("guest_ip", a.guestIp);
+                    o.put("guest_port", a.guestPort);
+                    arr.put(o);
+                } catch (JSONException ignored) {
+                }
+            }
+        }
+        return arr;
+    }
+
+    private void loop() {
+        var rules = parseRules();
+        if (rules.isEmpty()) return;
+        int attempts = 0;
+        while (running && vm.getState() == VMState.RUNNING) {
+            boolean allDone = true;
+            for (var rule : rules) {
+                if (rule.done) continue;
+                if (!running) return;
+                var target = resolveTarget(rule);
+                if (target == null) {
+                    allDone = false;
+                    continue;
+                }
+                boolean ok = networkStore.firewall.applyForward(
+                    target.bridge, target.ip, rule.protocol,
+                    rule.hostIp, rule.hostPort, rule.guestPort);
+                rule.done = true;
+                if (!ok) {
+                    Log.w(TAG, fmt("VM %s: failed to apply forward %s :%d -> %s:%d",
+                        vm.getName(), rule.protocol, rule.hostPort, target.ip, rule.guestPort));
+                    continue;
+                }
+                // 与 stop()/removeAll() 通过 applied 锁互斥，避免 stop 后仍残留规则
+                synchronized (applied) {
+                    if (!running) {
+                        networkStore.firewall.removeForward(
+                            target.bridge, target.ip, rule.protocol,
+                            rule.hostIp, rule.hostPort, rule.guestPort);
+                    } else {
+                        applied.add(new Applied(target.bridge, target.ip, rule.protocol,
+                            rule.hostIp, rule.hostPort, rule.guestPort));
+                        Log.i(TAG, fmt("VM %s: forward %s :%d -> %s:%d",
+                            vm.getName(), rule.protocol, rule.hostPort, target.ip, rule.guestPort));
+                    }
+                }
+            }
+            if (allDone) break;
+            if (++attempts >= RESOLVE_MAX_ATTEMPTS) {
+                Log.w(TAG, fmt("VM %s: gave up resolving guest IP for some port forwards after %d attempts",
+                    vm.getName(), attempts));
+                break;
+            }
+            threadSleep(RESOLVE_INTERVAL_MS);
+        }
+    }
+
+    private void removeAll() {
+        synchronized (applied) {
+            if (networkStore != null)
+                for (var a : applied)
+                    networkStore.firewall.removeForward(
+                        a.bridge, a.guestIp, a.protocol, a.hostIp, a.hostPort, a.guestPort);
+            applied.clear();
+        }
+    }
+
+    @NonNull
+    private List<Rule> parseRules() {
+        var list = new ArrayList<Rule>();
+        var pf = vm.item.opt("port_forwards", null);
+        if (pf == null || !pf.is(DataItem.Type.ARRAY)) return list;
+        var seen = new HashSet<String>();
+        for (var iter : pf) {
+            var r = iter.getValue();
+            if (!r.is(DataItem.Type.OBJECT)) continue;
+            if (!r.optBoolean("enabled", true)) continue;
+            var protocol = r.optString("protocol", "tcp");
+            if (protocol == null || protocol.isEmpty()) protocol = "tcp";
+            protocol = protocol.toLowerCase(Locale.ROOT);
+            if (!protocol.equals("tcp") && !protocol.equals("udp")) continue;
+            long hostPort = r.optLong("host_port", 0);
+            if (hostPort <= 0 || hostPort > 65535) continue;
+            long guestPort = r.optLong("guest_port", 0);
+            if (guestPort <= 0 || guestPort > 65535) guestPort = hostPort;
+            var hostIp = r.optString("host_ip", "");
+            if (hostIp == null) hostIp = "";
+            // 同一 VM 内按 (protocol, host_ip, host_port) 去重，避免重复 DNAT
+            var key = fmt("%s|%s|%d", protocol, hostIp, hostPort);
+            if (!seen.add(key)) {
+                Log.w(TAG, fmt("VM %s: duplicate port forward %s, skipping", vm.getName(), key));
+                continue;
+            }
+            var rule = new Rule();
+            rule.protocol = protocol;
+            rule.hostIp = hostIp;
+            rule.hostPort = (int) hostPort;
+            rule.guestPort = (int) guestPort;
+            rule.networkId = r.optString("network_id", "");
+            rule.fixedGuestIp = r.optString("guest_ip", "");
+            list.add(rule);
+        }
+        return list;
+    }
+
+    @Nullable
+    private Target resolveTarget(@NonNull Rule rule) {
+        var net = findNetwork(rule.networkId);
+        if (net == null) return null;
+        var netId = net.optString("network_id", "");
+        if (netId == null || netId.isEmpty()) return null;
+        var netInst = networkStore.findById(netId);
+        if (netInst == null) return null;
+        var bridge = netInst.item.optString("bridge_name", "");
+        if (bridge == null || bridge.isEmpty()) return null;
+        if (rule.fixedGuestIp != null && !rule.fixedGuestIp.isEmpty())
+            return new Target(bridge, rule.fixedGuestIp);
+        var mac = net.optString("mac_address", "");
+        if (mac == null || mac.isEmpty()) return null;
+        var ip = resolveGuestIpByMac(netInst, bridge, mac);
+        if (ip == null) return null;
+        return new Target(bridge, ip);
+    }
+
+    @Nullable
+    private String resolveGuestIpByMac(
+        @NonNull NetworkInstance netInst, @NonNull String bridge, @NonNull String mac) {
+        var macLower = mac.toLowerCase(Locale.ROOT);
+        // 1. 优先用 dnsmasq DHCP 租约
+        var ip = matchMac(networkStore.backend.listDhcpLeases(bridge), macLower, "ip", "mac");
+        if (ip != null) return ip;
+        // 2. 回退到 ARP 邻居表（适用于静态 IP 且已通信过的 guest）
+        return matchMac(netInst.listNeighbors(), macLower, "dst", "lladdr");
+    }
+
+    @Nullable
+    private static String matchMac(
+        @Nullable JSONArray arr, @NonNull String macLower,
+        @NonNull String ipKey, @NonNull String macKey) {
+        if (arr == null) return null;
+        for (int i = 0; i < arr.length(); i++) {
+            var o = arr.optJSONObject(i);
+            if (o == null) continue;
+            var m = o.optString(macKey, "");
+            if (!m.isEmpty() && m.toLowerCase(Locale.ROOT).equals(macLower)) {
+                var ip = o.optString(ipKey, "");
+                if (!ip.isEmpty()) return ip;
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    private DataItem findNetwork(@Nullable String networkId) {
+        var nets = vm.item.opt("networks", null);
+        if (nets == null || !nets.is(DataItem.Type.ARRAY)) return null;
+        DataItem first = null;
+        for (var iter : nets) {
+            var net = iter.getValue();
+            var nid = net.optString("network_id", "");
+            if (nid == null || nid.isEmpty()) continue;
+            if (first == null) first = net;
+            if (networkId == null || networkId.isEmpty()) return net;
+            if (networkId.equals(nid)) return net;
+        }
+        return first;
+    }
+
+    private static final class Applied {
+        final String bridge;
+        final String guestIp;
+        final String protocol;
+        final String hostIp;
+        final int hostPort;
+        final int guestPort;
+
+        Applied(String bridge, String guestIp, String protocol,
+                String hostIp, int hostPort, int guestPort) {
+            this.bridge = bridge;
+            this.guestIp = guestIp;
+            this.protocol = protocol;
+            this.hostIp = hostIp;
+            this.hostPort = hostPort;
+            this.guestPort = guestPort;
+        }
+    }
+
+    private static final class Rule {
+        String protocol;
+        String hostIp;
+        int hostPort;
+        int guestPort;
+        String networkId;
+        String fixedGuestIp;
+        boolean done = false;
+    }
+
+    private static final class Target {
+        final String bridge;
+        final String ip;
+
+        Target(String bridge, String ip) {
+            this.bridge = bridge;
+            this.ip = ip;
+        }
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/lib/store/vm/PortProtocol.java
+++ b/app/src/main/java/cn/classfun/droidvm/lib/store/vm/PortProtocol.java
@@ -1,0 +1,16 @@
+package cn.classfun.droidvm.lib.store.vm;
+
+import androidx.annotation.NonNull;
+
+import cn.classfun.droidvm.lib.store.enums.StringEnum;
+
+public enum PortProtocol implements StringEnum {
+    TCP,
+    UDP;
+
+    @NonNull
+    @Override
+    public String getString() {
+        return name();
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/edit/base/VMEditTab.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/edit/base/VMEditTab.java
@@ -17,6 +17,7 @@ import cn.classfun.droidvm.ui.vm.edit.basic.VMEditBasicTab;
 import cn.classfun.droidvm.ui.vm.edit.boot.VMEditBootTab;
 import cn.classfun.droidvm.ui.vm.edit.graphics.VMEditGraphicsTab;
 import cn.classfun.droidvm.ui.vm.edit.network.VMEditNetworkTab;
+import cn.classfun.droidvm.ui.vm.edit.portforward.VMEditPortForwardTab;
 import cn.classfun.droidvm.ui.vm.edit.storage.VMEditStorageTab;
 
 public enum VMEditTab implements StringEnum {
@@ -39,6 +40,11 @@ public enum VMEditTab implements StringEnum {
         R.string.create_vm_tab_network,
         R.id.tab_content_network,
         VMEditNetworkTab.class
+    ),
+    TAB_PORT_FORWARD(
+        R.string.create_vm_tab_port_forward,
+        R.id.tab_content_port_forward,
+        VMEditPortForwardTab.class
     ),
     TAB_GRAPHICS(
         R.string.create_vm_tab_graphics,

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/edit/portforward/PortForwardEditAdapter.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/edit/portforward/PortForwardEditAdapter.java
@@ -1,0 +1,174 @@
+package cn.classfun.droidvm.ui.vm.edit.portforward;
+
+import android.content.Context;
+import android.content.DialogInterface;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
+import java.util.ArrayList;
+
+import cn.classfun.droidvm.R;
+import cn.classfun.droidvm.lib.store.base.DataItem;
+import cn.classfun.droidvm.lib.store.enums.Enums;
+import cn.classfun.droidvm.lib.store.network.NetworkStore;
+import cn.classfun.droidvm.lib.store.vm.PortProtocol;
+import cn.classfun.droidvm.lib.ui.SimpleTextWatcher;
+import cn.classfun.droidvm.ui.widgets.container.CardItemAdapter;
+
+public final class PortForwardEditAdapter extends CardItemAdapter<PortForwardEditViewHolder> {
+    public PortForwardEditAdapter(@NonNull Context context) {
+        super(context);
+    }
+
+    @NonNull
+    @Override
+    protected PortForwardEditViewHolder createViewHolderInstance(@NonNull View view) {
+        return new PortForwardEditViewHolder(view);
+    }
+
+    @Override
+    protected int getLayoutRes() {
+        return R.layout.item_port_forward_edit;
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull PortForwardEditViewHolder holder, int position) {
+        var item = items.get(position);
+        holder.unbindWatchers();
+
+        holder.btnProtocol.configure(
+            PortProtocol.class, Enums.optEnum(item, "protocol", PortProtocol.TCP));
+        holder.btnProtocol.setOnValueChangedListener((oldVal, newVal) -> {
+            int pos = holder.getBindingAdapterPosition();
+            if (pos != RecyclerView.NO_POSITION)
+                items.get(pos).set("protocol", newVal);
+        });
+
+        long hostPort = item.optLong("host_port", 0);
+        holder.etHostPort.setText(hostPort > 0 ? String.valueOf(hostPort) : "");
+        holder.hostPortWatcher = SimpleTextWatcher.simpleAfterTextWatcher(s -> {
+            int pos = holder.getBindingAdapterPosition();
+            if (pos != RecyclerView.NO_POSITION)
+                setPort(items.get(pos), "host_port", s.toString());
+        });
+        holder.etHostPort.addTextChangedListener(holder.hostPortWatcher);
+
+        // Guest port (empty = same as host port, backend falls back)
+        long guestPort = item.optLong("guest_port", 0);
+        holder.etGuestPort.setText(guestPort > 0 ? String.valueOf(guestPort) : "");
+        holder.guestPortWatcher = SimpleTextWatcher.simpleAfterTextWatcher(s -> {
+            int pos = holder.getBindingAdapterPosition();
+            if (pos != RecyclerView.NO_POSITION)
+                setPort(items.get(pos), "guest_port", s.toString());
+        });
+        holder.etGuestPort.addTextChangedListener(holder.guestPortWatcher);
+
+        holder.switchEnabled.setOnCheckedChangeListener(null);
+        holder.switchEnabled.setChecked(item.optBoolean("enabled", true));
+        holder.switchEnabled.setOnCheckedChangeListener((btn, checked) -> {
+            int pos = holder.getBindingAdapterPosition();
+            if (pos != RecyclerView.NO_POSITION)
+                items.get(pos).set("enabled", checked);
+        });
+
+        holder.etHostIp.setText(item.optString("host_ip", ""));
+        holder.hostIpWatcher = SimpleTextWatcher.simpleAfterTextWatcher(s -> {
+            int pos = holder.getBindingAdapterPosition();
+            if (pos != RecyclerView.NO_POSITION)
+                items.get(pos).set("host_ip", s.toString().trim());
+        });
+        holder.etHostIp.addTextChangedListener(holder.hostIpWatcher);
+
+        holder.etGuestIp.setText(item.optString("guest_ip", ""));
+        holder.guestIpWatcher = SimpleTextWatcher.simpleAfterTextWatcher(s -> {
+            int pos = holder.getBindingAdapterPosition();
+            if (pos != RecyclerView.NO_POSITION)
+                items.get(pos).set("guest_ip", s.toString().trim());
+        });
+        holder.etGuestIp.addTextChangedListener(holder.guestIpWatcher);
+
+        updateNetworkButton(holder.btnNetwork, item.optString("network_id", ""));
+        holder.btnNetwork.setOnClickListener(v -> {
+            int pos = holder.getBindingAdapterPosition();
+            if (pos != RecyclerView.NO_POSITION)
+                showNetworkPicker(pos, holder.btnNetwork);
+        });
+
+        // Advanced section expand state: expanded by default when advanced values exist (data-driven, safe to reuse)
+        boolean hasAdvanced = !item.optString("host_ip", "").isEmpty()
+            || !item.optString("guest_ip", "").isEmpty()
+            || !item.optString("network_id", "").isEmpty();
+        applyAdvancedState(holder, hasAdvanced);
+        holder.btnAdvanced.setOnClickListener(v -> {
+            boolean show = holder.layoutAdvanced.getVisibility() != View.VISIBLE;
+            applyAdvancedState(holder, show);
+        });
+
+        holder.btnDelete.setOnClickListener(v -> {
+            int pos = holder.getBindingAdapterPosition();
+            if (pos != RecyclerView.NO_POSITION)
+                removeItem(pos);
+        });
+    }
+
+    private void applyAdvancedState(@NonNull PortForwardEditViewHolder holder, boolean expanded) {
+        holder.layoutAdvanced.setVisibility(expanded ? View.VISIBLE : View.GONE);
+        holder.btnAdvanced.setIconResource(
+            expanded ? R.drawable.ic_expand_less : R.drawable.ic_expand_more);
+    }
+
+    /** Writes the port as an integer; empty/invalid becomes 0 (backend: host_port=0 is skipped, guest_port=0 falls back to host_port). */
+    private void setPort(@NonNull DataItem item, @NonNull String key, @NonNull String text) {
+        text = text.trim();
+        if (text.isEmpty()) {
+            item.set(key, 0L);
+            return;
+        }
+        try {
+            item.set(key, (long) Integer.parseInt(text));
+        } catch (NumberFormatException e) {
+            item.set(key, 0L);
+        }
+    }
+
+    private void showNetworkPicker(int position, @NonNull MaterialButton btn) {
+        var netStore = new NetworkStore();
+        netStore.load(context);
+        var ids = new ArrayList<String>();
+        var names = new ArrayList<String>();
+        ids.add("");
+        names.add(context.getString(R.string.create_vm_network_none));
+        netStore.forEach((id, config) -> {
+            ids.add(id.toString());
+            names.add(config.getName());
+        });
+        var currentId = items.get(position).optString("network_id", "");
+        int checked = Math.max(0, ids.indexOf(currentId));
+        DialogInterface.OnClickListener onclick = (dialog, which) -> {
+            items.get(position).set("network_id", ids.get(which));
+            updateNetworkButton(btn, ids.get(which));
+            dialog.dismiss();
+        };
+        new MaterialAlertDialogBuilder(context)
+            .setTitle(R.string.edit_vm_pf_network)
+            .setSingleChoiceItems(names.toArray(new String[0]), checked, onclick)
+            .show();
+    }
+
+    private void updateNetworkButton(@NonNull MaterialButton btn, String networkId) {
+        if (networkId == null || networkId.isEmpty()) {
+            btn.setText(R.string.create_vm_network_none);
+            return;
+        }
+        var netStore = new NetworkStore();
+        netStore.load(context);
+        var net = netStore.findById(networkId);
+        btn.setText(net != null ? net.getName() :
+            context.getString(R.string.create_vm_network_none));
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/edit/portforward/PortForwardEditViewHolder.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/edit/portforward/PortForwardEditViewHolder.java
@@ -1,0 +1,66 @@
+package cn.classfun.droidvm.ui.vm.edit.portforward;
+
+import android.text.TextWatcher;
+import android.view.View;
+import android.widget.ImageButton;
+import android.widget.LinearLayout;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.materialswitch.MaterialSwitch;
+import com.google.android.material.textfield.TextInputEditText;
+
+import cn.classfun.droidvm.R;
+import cn.classfun.droidvm.ui.widgets.tools.PickerButtonWidget;
+
+public final class PortForwardEditViewHolder extends RecyclerView.ViewHolder {
+    final TextInputEditText etHostPort;
+    final TextInputEditText etGuestPort;
+    final TextInputEditText etHostIp;
+    final TextInputEditText etGuestIp;
+    final PickerButtonWidget btnProtocol;
+    final MaterialSwitch switchEnabled;
+    final MaterialButton btnAdvanced;
+    final MaterialButton btnNetwork;
+    final ImageButton btnDelete;
+    final LinearLayout layoutAdvanced;
+    TextWatcher hostPortWatcher;
+    TextWatcher guestPortWatcher;
+    TextWatcher hostIpWatcher;
+    TextWatcher guestIpWatcher;
+
+    PortForwardEditViewHolder(@NonNull View itemView) {
+        super(itemView);
+        etHostPort = itemView.findViewById(R.id.et_pf_host_port);
+        etGuestPort = itemView.findViewById(R.id.et_pf_guest_port);
+        etHostIp = itemView.findViewById(R.id.et_pf_host_ip);
+        etGuestIp = itemView.findViewById(R.id.et_pf_guest_ip);
+        btnProtocol = itemView.findViewById(R.id.btn_pf_protocol);
+        switchEnabled = itemView.findViewById(R.id.switch_pf_enabled);
+        btnAdvanced = itemView.findViewById(R.id.btn_pf_advanced);
+        btnNetwork = itemView.findViewById(R.id.btn_pf_network);
+        btnDelete = itemView.findViewById(R.id.btn_pf_delete);
+        layoutAdvanced = itemView.findViewById(R.id.layout_pf_advanced);
+    }
+
+    void unbindWatchers() {
+        if (hostPortWatcher != null) {
+            etHostPort.removeTextChangedListener(hostPortWatcher);
+            hostPortWatcher = null;
+        }
+        if (guestPortWatcher != null) {
+            etGuestPort.removeTextChangedListener(guestPortWatcher);
+            guestPortWatcher = null;
+        }
+        if (hostIpWatcher != null) {
+            etHostIp.removeTextChangedListener(hostIpWatcher);
+            hostIpWatcher = null;
+        }
+        if (guestIpWatcher != null) {
+            etGuestIp.removeTextChangedListener(guestIpWatcher);
+            guestIpWatcher = null;
+        }
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/edit/portforward/VMEditPortForwardTab.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/edit/portforward/VMEditPortForwardTab.java
@@ -1,0 +1,66 @@
+package cn.classfun.droidvm.ui.vm.edit.portforward;
+
+import static java.util.Objects.requireNonNull;
+
+import android.view.View;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+
+import cn.classfun.droidvm.R;
+import cn.classfun.droidvm.lib.store.base.DataItem;
+import cn.classfun.droidvm.lib.store.vm.VMConfig;
+import cn.classfun.droidvm.lib.store.vm.VMStore;
+import cn.classfun.droidvm.ui.vm.edit.VMEditActivity;
+import cn.classfun.droidvm.ui.vm.edit.base.VMEditBaseTab;
+import cn.classfun.droidvm.ui.widgets.container.CardItemListView;
+
+public final class VMEditPortForwardTab extends VMEditBaseTab {
+    private CardItemListView listPf;
+
+    public VMEditPortForwardTab(VMEditActivity parent, View view) {
+        super(parent, view);
+    }
+
+    @Override
+    public void initView() {
+        listPf = view.findViewById(R.id.list_port_forwards);
+    }
+
+    @Override
+    public void initValue() {
+        listPf.setAdapter(PortForwardEditAdapter.class);
+    }
+
+    @Override
+    public void loadConfig(@NonNull VMConfig config) {
+        listPf.setItems(config.item.opt("port_forwards", DataItem.newArray()));
+    }
+
+    @Override
+    public boolean validateInput(@NonNull VMStore store) {
+        if (!rulesValid(requireNonNull(listPf.getItems()))) {
+            Toast.makeText(parent, R.string.edit_vm_pf_invalid_port, Toast.LENGTH_SHORT).show();
+            return false;
+        }
+        return true;
+    }
+
+    /** Mirrors the backend VMPortForwarder.parseRules checks (enabled rules only). */
+    public static boolean rulesValid(@NonNull DataItem rules) {
+        for (var iter : rules) {
+            var r = iter.getValue();
+            if (!r.optBoolean("enabled", true)) continue;
+            long hostPort = r.optLong("host_port", 0);
+            if (hostPort <= 0 || hostPort > 65535) return false;
+            long guestPort = r.optLong("guest_port", 0);
+            if (guestPort > 65535) return false; // 0 is valid: backend falls back to host_port
+        }
+        return true;
+    }
+
+    @Override
+    public void saveConfig(@NonNull VMConfig config) {
+        config.item.set("port_forwards", listPf.getItems());
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/info/VMInfoActivity.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/info/VMInfoActivity.java
@@ -15,10 +15,14 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.google.android.material.appbar.CollapsingToolbarLayout;
@@ -26,6 +30,8 @@ import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
+import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.text.DateFormat;
@@ -46,6 +52,10 @@ import cn.classfun.droidvm.lib.store.vm.VMStore;
 import cn.classfun.droidvm.lib.ui.UIContext;
 import cn.classfun.droidvm.ui.vm.VMActions;
 import cn.classfun.droidvm.ui.vm.edit.VMEditActivity;
+import cn.classfun.droidvm.ui.vm.edit.portforward.PortForwardEditAdapter;
+import cn.classfun.droidvm.ui.vm.edit.portforward.VMEditPortForwardTab;
+import cn.classfun.droidvm.ui.widgets.container.CardItemListView;
+import cn.classfun.droidvm.ui.widgets.container.CollapsibleContainer;
 import cn.classfun.droidvm.ui.widgets.row.TextRowWidget;
 
 public final class VMInfoActivity extends AppCompatActivity implements ForegroundCallback {
@@ -74,6 +84,10 @@ public final class VMInfoActivity extends AppCompatActivity implements Foregroun
     private TextRowWidget rowDisks;
     private TextRowWidget rowOptions;
     private TextRowWidget rowCreated;
+    private CollapsibleContainer ccPortForwards;
+    private LinearLayout containerPortForwards;
+    private TextView tvPfEmpty;
+    private MaterialButton btnPfEdit;
     public VMState currentState = VMState.STOPPED;
     public UUID vmId;
     public VMConfig config;
@@ -101,6 +115,10 @@ public final class VMInfoActivity extends AppCompatActivity implements Foregroun
         rowDisks = findViewById(R.id.row_disks);
         rowOptions = findViewById(R.id.row_options);
         rowCreated = findViewById(R.id.row_created);
+        ccPortForwards = findViewById(R.id.cc_port_forwards);
+        containerPortForwards = findViewById(R.id.container_port_forwards);
+        tvPfEmpty = findViewById(R.id.tv_pf_empty);
+        btnPfEdit = findViewById(R.id.btn_pf_edit);
         toolbar = findViewById(R.id.toolbar);
         initialize();
     }
@@ -125,6 +143,7 @@ public final class VMInfoActivity extends AppCompatActivity implements Foregroun
             sendControlCommand("powerbtn", vmId, mainHandler, ui));
         btnSleepBtn.setOnClickListener(v ->
             sendControlCommand("sleepbtn", vmId, mainHandler, ui));
+        btnPfEdit.setOnClickListener(v -> showPortForwardEditor());
     }
 
     @Override
@@ -292,6 +311,121 @@ public final class VMInfoActivity extends AppCompatActivity implements Foregroun
             tvStateDetail.setText(R.string.vm_info_state_suspended);
         } else {
             tvStateDetail.setText("");
+        }
+        refreshPortForwards();
+        if (isRunning)
+            mainHandler.postDelayed(this::refreshPortForwards, 2000);
+    }
+
+    private void refreshPortForwards() {
+        if (currentState != VMState.RUNNING) {
+            ccPortForwards.setVisibility(View.GONE);
+            return;
+        }
+        DaemonConnection.OnResponse res = resp -> {
+            var data = resp.optJSONObject("data");
+            var active = data != null ? data.optJSONArray("active") : null;
+            mainHandler.post(() -> renderPortForwards(active));
+        };
+        DaemonConnection.getInstance().buildRequest("vm_port_forward_list")
+            .put("vm_id", vmId.toString())
+            .onResponse(res)
+            .onUnsuccessful(r -> {
+            })
+            .onError(e -> Log.w(TAG, "Failed to query port forwards", e))
+            .invoke();
+    }
+
+    private void renderPortForwards(@Nullable JSONArray active) {
+        if (isFinishing()) return;
+        if (currentState != VMState.RUNNING) {
+            ccPortForwards.setVisibility(View.GONE);
+            return;
+        }
+        ccPortForwards.setVisibility(View.VISIBLE);
+        containerPortForwards.removeAllViews();
+        int count = active != null ? active.length() : 0;
+        if (count == 0) {
+            tvPfEmpty.setVisibility(View.VISIBLE);
+            return;
+        }
+        tvPfEmpty.setVisibility(View.GONE);
+        var inflater = LayoutInflater.from(this);
+        for (int i = 0; i < count; i++) {
+            var o = active.optJSONObject(i);
+            if (o == null) continue;
+            var protocol = o.optString("protocol", "tcp");
+            var proto = "udp".equals(protocol) ? "UDP" : "TCP";
+            var hostIp = o.optString("host_ip", "");
+            var hostPort = o.optInt("host_port", 0);
+            var guestIp = o.optString("guest_ip", "");
+            var guestPort = o.optInt("guest_port", 0);
+            var hostDisplay = (hostIp.isEmpty() ? "*" : hostIp) + ":" + hostPort;
+            var line = proto + "  " + hostDisplay + " -> " + guestIp + ":" + guestPort;
+            var row = inflater.inflate(
+                R.layout.item_port_forward_active, containerPortForwards, false);
+            ((TextView) row.findViewById(R.id.tv_pf_line)).setText(line);
+            containerPortForwards.addView(row);
+        }
+    }
+
+    private void showPortForwardEditor() {
+        if (config == null) return;
+        var view = LayoutInflater.from(this).inflate(R.layout.dialog_port_forward_edit, null);
+        CardItemListView list = view.findViewById(R.id.list_port_forwards);
+        list.setAdapter(PortForwardEditAdapter.class);
+        list.setItems(copyArray(config.item.opt("port_forwards", DataItem.newArray())));
+        var dialog = new MaterialAlertDialogBuilder(this)
+            .setTitle(R.string.vm_info_port_forwards)
+            .setView(view)
+            .setPositiveButton(R.string.edit_vm_pf_apply, null)
+            .setNegativeButton(android.R.string.cancel, null)
+            .create();
+        // Override the button so failed validation keeps the dialog open.
+        dialog.setOnShowListener(d -> dialog.getButton(AlertDialog.BUTTON_POSITIVE)
+            .setOnClickListener(v -> {
+                if (applyPortForwardEdits(list)) dialog.dismiss();
+            }));
+        dialog.show();
+    }
+
+    private boolean applyPortForwardEdits(CardItemListView list) {
+        var items = list.getItems();
+        if (items == null) items = DataItem.newArray();
+        if (!VMEditPortForwardTab.rulesValid(items)) {
+            Toast.makeText(this, R.string.edit_vm_pf_invalid_port, Toast.LENGTH_SHORT).show();
+            return false;
+        }
+        config.item.set("port_forwards", items);
+        runOnPool(() -> store.save(this));
+        JSONArray rules;
+        try {
+            rules = items.toJsonArray();
+        } catch (JSONException e) {
+            rules = new JSONArray();
+        }
+        DaemonConnection.getInstance().buildRequest("vm_port_forward_set")
+            .put("vm_id", vmId.toString())
+            .put("rules", rules)
+            .onResponse(r -> {
+                // Apply may take effect sync (reconcile) or async (loop start); refresh now and after a delay.
+                mainHandler.post(this::refreshPortForwards);
+                mainHandler.postDelayed(this::refreshPortForwards, 1500);
+            })
+            .onUnsuccessful(r -> {
+            })
+            .onError(e -> Log.w(TAG, "Failed to set port forwards", e))
+            .invoke();
+        return true;
+    }
+
+    /** Deep copy so a cancelled dialog doesn't mutate config. */
+    private static DataItem copyArray(DataItem src) {
+        if (!src.is(DataItem.Type.ARRAY)) return DataItem.newArray();
+        try {
+            return DataItem.fromJson(src.toJsonArray());
+        } catch (JSONException e) {
+            return DataItem.newArray();
         }
     }
 

--- a/app/src/main/res/layout/activity_vm_edit.xml
+++ b/app/src/main/res/layout/activity_vm_edit.xml
@@ -82,6 +82,13 @@
                 android:visibility="gone" />
 
             <include
+                android:id="@+id/tab_content_port_forward"
+                layout="@layout/partial_vm_edit_port_forward"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone" />
+
+            <include
                 android:id="@+id/tab_content_graphics"
                 layout="@layout/partial_vm_edit_graphics"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_vm_info.xml
+++ b/app/src/main/res/layout/activity_vm_info.xml
@@ -286,6 +286,45 @@
 
             </cn.classfun.droidvm.ui.widgets.container.CollapsibleContainer>
 
+            <cn.classfun.droidvm.ui.widgets.container.CollapsibleContainer
+                android:id="@+id/cc_port_forwards"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:title="@string/vm_info_port_forwards"
+                android:visibility="gone">
+
+                <LinearLayout
+                    android:id="@+id/container_port_forwards"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:paddingBottom="8dp" />
+
+                <TextView
+                    android:id="@+id/tv_pf_empty"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingStart="16dp"
+                    android:paddingEnd="16dp"
+                    android:paddingTop="4dp"
+                    android:paddingBottom="12dp"
+                    android:text="@string/vm_info_pf_none"
+                    android:textColor="?attr/colorOnSurfaceVariant"
+                    android:textSize="14sp" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btn_pf_edit"
+                    style="@style/Widget.Material3.Button.TonalButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginEnd="16dp"
+                    android:layout_marginBottom="8dp"
+                    android:text="@string/vm_info_pf_edit"
+                    app:icon="@drawable/ic_edit" />
+
+            </cn.classfun.droidvm.ui.widgets.container.CollapsibleContainer>
+
             <Space
                 android:layout_width="match_parent"
                 android:layout_height="128dp" />

--- a/app/src/main/res/layout/dialog_port_forward_edit.xml
+++ b/app/src/main/res/layout/dialog_port_forward_edit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp">
+
+    <cn.classfun.droidvm.ui.widgets.container.CardItemListView
+        android:id="@+id/list_port_forwards"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/edit_vm_pf_empty"
+        android:icon="@drawable/ic_add"
+        android:text="@string/edit_vm_pf_add" />
+
+</ScrollView>

--- a/app/src/main/res/layout/item_port_forward_active.xml
+++ b/app/src/main/res/layout/item_port_forward_active.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:paddingTop="6dp"
+    android:paddingBottom="6dp">
+
+    <ImageView
+        android:layout_width="20dp"
+        android:layout_height="20dp"
+        android:contentDescription="@string/vm_info_port_forwards"
+        android:src="@drawable/ic_arrow_forward"
+        app:tint="?attr/colorOnSurfaceVariant" />
+
+    <TextView
+        android:id="@+id/tv_pf_line"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:fontFamily="monospace"
+        android:textColor="?attr/colorOnSurface"
+        android:textSize="14sp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_port_forward_edit.xml
+++ b/app/src/main/res/layout/item_port_forward_edit.xml
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="16dp"
+    android:layout_marginEnd="16dp"
+    android:layout_marginBottom="8dp"
+    app:cardCornerRadius="12dp"
+    app:cardElevation="0dp"
+    app:strokeColor="?attr/colorOutlineVariant"
+    app:strokeWidth="1dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="12dp">
+
+        <!-- 第 1 行：主机端口 → Guest 端口 + 删除 -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:contentDescription="@string/create_vm_category_port_forward"
+                android:src="@drawable/ic_arrow_forward"
+                app:tint="?attr/colorOnSurfaceVariant" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/til_pf_host_port"
+                style="@style/Widget.Material3.TextInputLayout.OutlinedBox.Dense"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:layout_weight="1"
+                android:hint="@string/edit_vm_pf_host_port">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/et_pf_host_port"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="number"
+                    android:maxLength="5"
+                    android:maxLines="1"
+                    android:textSize="14sp"
+                    tools:ignore="TextContrastCheck,VisualLintTextFieldSize" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
+                android:text="@string/edit_vm_pf_arrow"
+                android:textColor="?attr/colorOnSurfaceVariant"
+                android:textSize="16sp" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/til_pf_guest_port"
+                style="@style/Widget.Material3.TextInputLayout.OutlinedBox.Dense"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:hint="@string/edit_vm_pf_guest_port">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/et_pf_guest_port"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="number"
+                    android:maxLength="5"
+                    android:maxLines="1"
+                    android:textSize="14sp"
+                    tools:ignore="TextContrastCheck,VisualLintTextFieldSize" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <ImageButton
+                android:id="@+id/btn_pf_delete"
+                android:layout_width="36dp"
+                android:layout_height="36dp"
+                android:layout_marginStart="4dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/edit_vm_pf_delete"
+                android:src="@drawable/ic_delete"
+                app:tint="?attr/colorError"
+                tools:ignore="TouchTargetSizeCheck" />
+
+        </LinearLayout>
+
+        <!-- 第 2 行：协议 + 高级 + 启用开关 -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <cn.classfun.droidvm.ui.widgets.tools.PickerButtonWidget
+                android:id="@+id/btn_pf_protocol"
+                android:layout_width="wrap_content"
+                android:layout_height="48dp"
+                android:title="@string/edit_vm_pf_protocol"
+                app:pb_mode="dialog" />
+
+            <Space
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_pf_advanced"
+                style="@style/Widget.Material3.Button.TextButton.Icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:minWidth="0dp"
+                android:text="@string/edit_vm_pf_advanced"
+                android:textSize="12sp"
+                app:icon="@drawable/ic_expand_more"
+                app:iconSize="18dp"
+                tools:ignore="TouchTargetSizeCheck" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:labelFor="@id/switch_pf_enabled"
+                android:text="@string/edit_vm_pf_enabled"
+                android:textSize="14sp" />
+
+            <com.google.android.material.materialswitch.MaterialSwitch
+                android:id="@+id/switch_pf_enabled"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp" />
+
+        </LinearLayout>
+
+        <!-- 第 3 段：高级选项（默认折叠） -->
+        <LinearLayout
+            android:id="@+id/layout_pf_advanced"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/til_pf_host_ip"
+                style="@style/Widget.Material3.TextInputLayout.OutlinedBox.Dense"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:hint="@string/edit_vm_pf_host_ip">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/et_pf_host_ip"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="textNoSuggestions"
+                    android:maxLines="1"
+                    android:textSize="14sp"
+                    tools:ignore="TextContrastCheck,VisualLintTextFieldSize" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_pf_network"
+                style="@style/Widget.Material3.Button.TonalButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:gravity="start|center_vertical"
+                android:text="@string/create_vm_network_none"
+                android:textSize="12sp"
+                app:icon="@drawable/ic_ethernet"
+                app:iconSize="18dp"
+                tools:ignore="VisualLintButtonSize" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/til_pf_guest_ip"
+                style="@style/Widget.Material3.TextInputLayout.OutlinedBox.Dense"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:hint="@string/edit_vm_pf_guest_ip">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/et_pf_guest_ip"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="textNoSuggestions"
+                    android:maxLines="1"
+                    android:textSize="14sp"
+                    tools:ignore="TextContrastCheck,VisualLintTextFieldSize" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/partial_vm_edit_port_forward.xml
+++ b/app/src/main/res/layout/partial_vm_edit_port_forward.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <cn.classfun.droidvm.ui.widgets.container.CollapsibleContainer
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:title="@string/create_vm_category_port_forward">
+
+        <cn.classfun.droidvm.ui.widgets.container.CardItemListView
+            android:id="@+id/list_port_forwards"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/edit_vm_pf_empty"
+            android:icon="@drawable/ic_add"
+            android:text="@string/edit_vm_pf_add" />
+
+    </cn.classfun.droidvm.ui.widgets.container.CollapsibleContainer>
+
+</LinearLayout>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -224,6 +224,26 @@
     <string name="edit_vm_net_delete">移除网络</string>
     <string name="edit_vm_net_mac_hint">MAC 地址（可选）</string>
     <string name="edit_vm_net_mac_random">随机</string>
+    <!-- 端口转发 -->
+    <string name="create_vm_tab_port_forward">端口</string>
+    <string name="create_vm_category_port_forward">端口转发</string>
+    <string name="edit_vm_pf_add">添加规则</string>
+    <string name="edit_vm_pf_empty">暂无端口转发规则。</string>
+    <string name="edit_vm_pf_delete">删除规则</string>
+    <string name="edit_vm_pf_protocol">协议</string>
+    <string name="edit_vm_pf_host_port">主机端口</string>
+    <string name="edit_vm_pf_guest_port">Guest 端口</string>
+    <string name="edit_vm_pf_arrow">→</string>
+    <string name="edit_vm_pf_enabled">启用</string>
+    <string name="edit_vm_pf_advanced">高级</string>
+    <string name="edit_vm_pf_host_ip">主机 IP（可选）</string>
+    <string name="edit_vm_pf_guest_ip">Guest IP（留空自动发现）</string>
+    <string name="edit_vm_pf_network">网卡</string>
+    <string name="edit_vm_pf_invalid_port">主机端口须为 1-65535</string>
+    <string name="vm_info_port_forwards">端口转发</string>
+    <string name="vm_info_pf_none">暂无生效转发</string>
+    <string name="vm_info_pf_edit">编辑转发</string>
+    <string name="edit_vm_pf_apply">应用</string>
     <string name="edit_vm_disk_path_hint">路径</string>
     <string name="edit_vm_disk_readonly">只读</string>
     <string name="edit_vm_disk_bus">总线</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -226,6 +226,26 @@
     <string name="edit_vm_net_delete">Remove network</string>
     <string name="edit_vm_net_mac_hint">MAC address (optional)</string>
     <string name="edit_vm_net_mac_random">Random</string>
+    <!-- Port forwarding -->
+    <string name="create_vm_tab_port_forward">Ports</string>
+    <string name="create_vm_category_port_forward">Port Forwarding</string>
+    <string name="edit_vm_pf_add">Add Rule</string>
+    <string name="edit_vm_pf_empty">No port forwarding rules.</string>
+    <string name="edit_vm_pf_delete">Remove rule</string>
+    <string name="edit_vm_pf_protocol">Protocol</string>
+    <string name="edit_vm_pf_host_port">Host Port</string>
+    <string name="edit_vm_pf_guest_port">Guest Port</string>
+    <string name="edit_vm_pf_arrow">→</string>
+    <string name="edit_vm_pf_enabled">Enabled</string>
+    <string name="edit_vm_pf_advanced">Advanced</string>
+    <string name="edit_vm_pf_host_ip">Host IP (optional)</string>
+    <string name="edit_vm_pf_guest_ip">Guest IP (auto if empty)</string>
+    <string name="edit_vm_pf_network">Network</string>
+    <string name="edit_vm_pf_invalid_port">Host port must be 1-65535</string>
+    <string name="vm_info_port_forwards">Port Forwarding</string>
+    <string name="vm_info_pf_none">No active forwards</string>
+    <string name="vm_info_pf_edit">Edit Forwards</string>
+    <string name="edit_vm_pf_apply">Apply</string>
     <string name="edit_vm_disk_path_hint">Path</string>
     <string name="edit_vm_disk_readonly">Read-only</string>
     <string name="edit_vm_disk_bus">Bus</string>


### PR DESCRIPTION
This pull request introduces a runtime port forwarding management system for VMs, allowing dynamic configuration and synchronization of port forwarding rules without requiring VM restarts. The changes add new IPC handlers for listing and updating port forwarding rules, extend the firewall and iptables backend to support rule application/removal, and implement logic in `VMInstance` to manage port forwarding lifecycles and expose relevant APIs.

**Port forwarding management and IPC:**

* Added `PortForwardListHandler` and `PortForwardSetHandler` IPC handlers to allow clients to list and set VM port forwarding rules at runtime, returning both configured and active rules. (`PortForwardListHandler.java` [[1]](diffhunk://#diff-06256a82416c4dded46146cb6f142fd8cc467da674c0baa3652c15a2a5b04a31R1-R37) `PortForwardSetHandler.java` [[2]](diffhunk://#diff-689e99721d29a86db1f59b0bf34b55ac8c08d07a027966633b3a584fdd68f0a2R1-R46)
* `VMInstance` now exposes methods to get configured/active port forwards and apply new rules at runtime, updating in-memory state and immediately syncing to iptables. (`VMInstance.java` [app/src/main/java/cn/classfun/droidvm/daemon/vm/VMInstance.javaR370-R417](diffhunk://#diff-203df65dc4e4c1c79314ee8513f8aa145da899dd6ed9c3ee74289b5efa9a695aR370-R417))

**Firewall and iptables backend enhancements:**

* Introduced abstract methods `applyForward` and `removeForward` in `FirewallHelper` to generalize port forwarding rule management. (`FirewallHelper.java` [app/src/main/java/cn/classfun/droidvm/daemon/network/backend/FirewallHelper.javaR18-R25](diffhunk://#diff-bf78e358ff41dc83fbaa5147b6f6253c980ec35f167d736d7d8c2f291dacf768R18-R25))
* Implemented `applyForward` and `removeForward` in `IptablesBackend` to manage DNAT and filter rules, including correct handling of wildcard addresses. (`IptablesBackend.java` [app/src/main/java/cn/classfun/droidvm/daemon/network/backend/iptables/IptablesBackend.javaR114-R185](diffhunk://#diff-e7edad0e9e4feb096c8c16fc6a9f5f76e267f73e6755a26be51a93ee982d3d2eR114-R185))
* Added `insert` method to `ChainInfo` to support prepending iptables rules (used for port forwarding). (`ChainInfo.java` [app/src/main/java/cn/classfun/droidvm/daemon/network/backend/iptables/ChainInfo.javaR60-R71](diffhunk://#diff-0a7c172db62800efb172b1b89e3809239ff9247aa5550ea88f07545c9dadb84aR60-R71))

**VM lifecycle integration:**

* `VMInstance` now starts and stops a `VMPortForwarder` alongside VM execution to manage the application and cleanup of port forwarding rules. (`VMInstance.java` [[1]](diffhunk://#diff-203df65dc4e4c1c79314ee8513f8aa145da899dd6ed9c3ee74289b5efa9a695aR45) [[2]](diffhunk://#diff-203df65dc4e4c1c79314ee8513f8aa145da899dd6ed9c3ee74289b5efa9a695aR325) [[3]](diffhunk://#diff-203df65dc4e4c1c79314ee8513f8aa145da899dd6ed9c3ee74289b5efa9a695aR350)

These changes enable live, API-driven port forwarding for VMs, improving flexibility and control for users and front-end integrations.
<img width="1264" height="2780" alt="Screenshot_2026-06-01-02-30-11-21_d6c8a1daae099e" src="https://github.com/user-attachments/assets/dc5d4d02-782e-4cc0-9ca2-ea41b3b06bbc" />
<img width="1264" height="2780" alt="Screenshot_2026-06-01-02-30-20-59_d6c8a1daae099e" src="https://github.com/user-attachments/assets/618b63af-edd9-452e-94a7-52f5f705181a" />

