### PR TITLE
Set up run directory ownership and disable mthp lending in agent

### DIFF
--- a/app/src/main/java/cn/classfun/droidvm/lib/daemon/DaemonHelper.java
+++ b/app/src/main/java/cn/classfun/droidvm/lib/daemon/DaemonHelper.java
@@ -19,6 +19,7 @@ import static cn.classfun.droidvm.lib.utils.ThreadUtils.threadSleepOrKill;
 
 import android.os.Handler;
 import android.os.Looper;
+import android.os.Process;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -100,7 +101,11 @@ public final class DaemonHelper {
     public boolean startDaemon() {
         var zipPath = getDaemonZipPath();
         Log.i(TAG, fmt("Starting daemon via app_process64 with %s", zipPath));
-        run("mkdir -p %s", pathJoin(DATA_DIR, "run"));
+        var runDir = pathJoin(DATA_DIR, "run");
+        var uid = Process.myUid();
+        run("mkdir -p %s", runDir);
+        // Best-effort ownership fix; chown may be denied on some contexts (e.g. Android).
+        run("chown %d:%d %s || true", uid, uid, runDir);
         var cmd = fmt(
             "env CLASSPATH=%s %s %s / %s",
             escapedString(zipPath),

--- a/app/src/main/java/cn/classfun/droidvm/ui/agent/base/AgentVM.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/agent/base/AgentVM.java
@@ -107,6 +107,7 @@ public final class AgentVM implements JSONSerialize {
         vm.item.set("temporary", true);
         vm.item.set("cpu_count", 1);
         vm.item.set("memory_mb", 384);
+        vm.item.set("prepare_lend_mthp", false);
         vm.item.set("use_uefi", false);
         vm.item.set("kernel", PATH_BUILTIN_KERNEL);
         vm.item.set("initrd", PATH_BUILTIN_INITRD);


### PR DESCRIPTION
This pull request introduces improvements for daemon startup permissions and adds a new configuration option for virtual machines. The main changes ensure the daemon's runtime directory has the correct ownership and allow for more granular VM configuration.

**Daemon startup improvements:**
* The `startDaemon()` method in `DaemonHelper.java` now sets the ownership of the `run` directory to the current process user, ensuring correct permissions for daemon operations. [[1]](diffhunk://#diff-539a7b686fc4ae7a0d6186d96a899ee35e49424ad7007cbbaf91ed6aed5ba276R22) [[2]](diffhunk://#diff-539a7b686fc4ae7a0d6186d96a899ee35e49424ad7007cbbaf91ed6aed5ba276L103-R106)

**VM configuration enhancements:**
* The `AgentVM.java` class now sets the `prepare_lend_mthp` option to `false` by default when building a VM, providing finer control over VM preparation behavior.