### PR TITLE
feat(settings): add option to clear logs before starting VM

### DIFF
--- a/app/src/main/java/cn/classfun/droidvm/daemon/console/ConsoleStream.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/console/ConsoleStream.java
@@ -109,21 +109,22 @@ public abstract class ConsoleStream implements Closeable, JSONSerialize {
 
     public void clear() {
         buffer.clear();
+        disableSave = false;
         if (logWriter != null) {
             try {
                 logWriter.close();
             } catch (Exception e) {
                 Log.w(TAG, "Failed to close console log output stream", e);
             }
-            try {
-                var path = getPersistentPath();
-                var file = new File(path);
-                if (file.exists() && !file.delete())
-                    Log.w(TAG, fmt("Failed to delete console log file %s", path));
-            } catch (Exception e) {
-                Log.w(TAG, "Failed to delete console log file", e);
-            }
             logWriter = null;
+        }
+        try {
+            var path = getPersistentPath();
+            var file = new File(path);
+            if (file.exists() && !file.delete())
+                Log.w(TAG, fmt("Failed to delete console log file %s", path));
+        } catch (Exception e) {
+            Log.w(TAG, "Failed to delete console log file", e);
         }
     }
 

--- a/app/src/main/java/cn/classfun/droidvm/daemon/ipc/vm/StartHandler.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/ipc/vm/StartHandler.java
@@ -9,6 +9,7 @@ import com.google.auto.service.AutoService;
 import cn.classfun.droidvm.daemon.server.ClientRequest;
 import cn.classfun.droidvm.daemon.server.RequestException;
 import cn.classfun.droidvm.daemon.server.RequestHandler;
+import cn.classfun.droidvm.lib.store.vm.VMState;
 
 @AutoService(RequestHandler.class)
 public final class StartHandler extends RequestHandler {
@@ -28,6 +29,9 @@ public final class StartHandler extends RequestHandler {
         var inst = vms.findById(vmId);
         if (inst == null)
             throw new RequestException(fmt("VM not found: %s", vmId));
+        if (params.optBoolean("clear_logs_before_start", false) &&
+            inst.getState() == VMState.STOPPED)
+            inst.clearLogs();
         if (!inst.start())
             throw new RequestException("failed to start VM");
     }

--- a/app/src/main/java/cn/classfun/droidvm/daemon/vm/VMInstance.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/vm/VMInstance.java
@@ -305,6 +305,11 @@ public final class VMInstance extends VMConfig {
         }
     }
 
+    public void clearLogs() {
+        for (var stream : getStreams())
+            stream.clear();
+    }
+
     private void runVM() {
         var inst = getBackendInstance();
         var vmId = getId().toString();

--- a/app/src/main/java/cn/classfun/droidvm/ui/main/settings/MainSettingsFragment.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/main/settings/MainSettingsFragment.java
@@ -45,6 +45,7 @@ public final class MainSettingsFragment extends MainBaseFragment {
     private static final long DAEMON_REFRESH_INTERVAL_MS = 1000L;
     private static final String PREFS_NAME = "droidvm_prefs";
     public static final String KEY_VM_AUTO_CONSOLE = "vm_auto_console";
+    public static final String KEY_VM_CLEAR_LOGS_BEFORE_START = "vm_clear_logs_before_start";
     public static final String KEY_AUTO_CHECK_UPDATE = "auto_check_update";
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
     private final Runnable daemonStatusRefreshRunnable = this::periodRefreshDaemonStatus;
@@ -57,6 +58,7 @@ public final class MainSettingsFragment extends MainBaseFragment {
     private TextRowWidget itemDaemonStop;
     private TextRowWidget itemDaemonRestart;
     private SwitchRowWidget itemVMAutoConsole;
+    private SwitchRowWidget itemVMClearLogsBeforeStart;
     private TextRowWidget itemLicense;
     private SwitchRowWidget itemAutoCheckUpdate;
     private TextRowWidget itemCheckUpdate;
@@ -104,6 +106,7 @@ public final class MainSettingsFragment extends MainBaseFragment {
         itemDaemonStop = view.findViewById(R.id.item_daemon_stop);
         itemDaemonRestart = view.findViewById(R.id.item_daemon_restart);
         itemVMAutoConsole = view.findViewById(R.id.item_vm_auto_console);
+        itemVMClearLogsBeforeStart = view.findViewById(R.id.item_vm_clear_logs_before_start);
         itemLicense = view.findViewById(R.id.item_license);
         itemAutoCheckUpdate = view.findViewById(R.id.item_auto_check_update);
         itemCheckUpdate = view.findViewById(R.id.item_check_update);
@@ -123,6 +126,7 @@ public final class MainSettingsFragment extends MainBaseFragment {
         bindOnClick(itemDaemonStop, daemon::asyncStopDaemon);
         bindOnClick(itemDaemonRestart, daemon::asyncRestartDaemon);
         bindOnChecked(itemVMAutoConsole, KEY_VM_AUTO_CONSOLE, false);
+        bindOnChecked(itemVMClearLogsBeforeStart, KEY_VM_CLEAR_LOGS_BEFORE_START, false);
         bindOnChecked(itemAutoCheckUpdate, KEY_AUTO_CHECK_UPDATE, true);
         bindOnClick(itemCheckUpdate, this::checkUpdate);
         bindOnClick(itemPrivacy, this::showPrivacyPolicy);
@@ -157,6 +161,11 @@ public final class MainSettingsFragment extends MainBaseFragment {
     public static boolean isAutoConsoleEnabled(@NonNull Context context) {
         var prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
         return prefs.getBoolean(KEY_VM_AUTO_CONSOLE, false);
+    }
+
+    public static boolean isClearLogsBeforeStartEnabled(@NonNull Context context) {
+        var prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        return prefs.getBoolean(KEY_VM_CLEAR_LOGS_BEFORE_START, false);
     }
 
     public static boolean isAutoCheckUpdateEnabled(@NonNull Context context) {

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/VMActions.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/VMActions.java
@@ -2,6 +2,7 @@ package cn.classfun.droidvm.ui.vm;
 
 import static android.widget.Toast.LENGTH_LONG;
 import static cn.classfun.droidvm.ui.main.settings.MainSettingsFragment.isAutoConsoleEnabled;
+import static cn.classfun.droidvm.ui.main.settings.MainSettingsFragment.isClearLogsBeforeStartEnabled;
 
 import android.os.Handler;
 import android.util.Log;
@@ -44,6 +45,7 @@ public final class VMActions {
         DaemonConnection.OnResponse onCreateModify = resp -> conn
             .buildRequest("vm_start")
             .copy(resp, "vm_id")
+            .put("clear_logs_before_start", isClearLogsBeforeStartEnabled(ui.getContext()))
             .onResponse(onStart)
             .onUnsuccessful(f)
             .onError(err)

--- a/app/src/main/res/layout/fragment_main_settings.xml
+++ b/app/src/main/res/layout/fragment_main_settings.xml
@@ -55,6 +55,14 @@
                     android:subtitle="@string/settings_vm_auto_console_summary"
                     android:text="@string/settings_vm_auto_console_title" />
 
+                <cn.classfun.droidvm.ui.widgets.row.SwitchRowWidget
+                    android:id="@+id/item_vm_clear_logs_before_start"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:icon="@drawable/ic_logs"
+                    android:subtitle="@string/settings_vm_clear_logs_before_start_summary"
+                    android:text="@string/settings_vm_clear_logs_before_start_title" />
+
             </cn.classfun.droidvm.ui.widgets.container.CollapsibleContainer>
 
             <cn.classfun.droidvm.ui.widgets.container.CollapsibleContainer

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -293,6 +293,8 @@
     <string name="settings_category_vm">虚拟机</string>
     <string name="settings_vm_auto_console_title">启动时打开控制台</string>
     <string name="settings_vm_auto_console_summary">启动虚拟机时自动打开控制台</string>
+    <string name="settings_vm_clear_logs_before_start_title">启动前清理日志</string>
+    <string name="settings_vm_clear_logs_before_start_summary">启动虚拟机前清理该虚拟机的所有控制台日志</string>
     <string name="settings_category_about">关于</string>
     <string name="settings_feedback_title">问题反馈</string>
     <string name="settings_feedback_summary">在 GitHub 上报告问题</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -295,6 +295,8 @@
     <string name="settings_category_vm">Virtual Machine</string>
     <string name="settings_vm_auto_console_title">Open console on start</string>
     <string name="settings_vm_auto_console_summary">Automatically open the console when a VM is started</string>
+    <string name="settings_vm_clear_logs_before_start_title">Clear logs before start</string>
+    <string name="settings_vm_clear_logs_before_start_summary">Clear all console logs for the VM before it starts</string>
     <string name="settings_category_about">About</string>
     <string name="settings_feedback_title">Feedback</string>
     <string name="settings_feedback_summary">Report issues on GitHub</string>


### PR DESCRIPTION
This pull request adds a new feature that allows users to automatically clear all console logs of a virtual machine before it starts, controlled by a new setting in the UI. The implementation involves changes to the settings interface, VM start logic, and log management, as well as updates to localization and layout files.

**New feature: Clear VM logs before start**

* Added a new setting (`KEY_VM_CLEAR_LOGS_BEFORE_START`) to allow users to enable or disable clearing of VM logs before starting a VM. This includes UI updates in `MainSettingsFragment`, a new switch in the settings layout, and corresponding string resources for both English and Chinese. [[1]](diffhunk://#diff-d67b5c4865b33ef5cee3fded2ee2374db6fe2bed4281b5335166869da97227b3R48) [[2]](diffhunk://#diff-d67b5c4865b33ef5cee3fded2ee2374db6fe2bed4281b5335166869da97227b3R61) [[3]](diffhunk://#diff-d67b5c4865b33ef5cee3fded2ee2374db6fe2bed4281b5335166869da97227b3R109) [[4]](diffhunk://#diff-d67b5c4865b33ef5cee3fded2ee2374db6fe2bed4281b5335166869da97227b3R129) [[5]](diffhunk://#diff-d67b5c4865b33ef5cee3fded2ee2374db6fe2bed4281b5335166869da97227b3R166-R170) [[6]](diffhunk://#diff-42fdc93dc8c7481812f76d2f499772f96ec19db647179448097cc77e7d2022ddR58-R65) [[7]](diffhunk://#diff-5e01f7d37a66e4ca03deefc205d8e7008661cdd0284a05aaba1858e6b7bf9103R298-R299) [[8]](diffhunk://#diff-d9c30b0c0a46ff73de30b4ec09e9219f1edad9a9ce584661d8170e5545d6aa50R296-R297)

**VM start logic and log clearing**

* Modified the VM start process (`VMActions.java` and `StartHandler.java`) to pass the new setting to the backend and clear logs if the option is enabled and the VM is currently stopped. [[1]](diffhunk://#diff-a8d14bf6a01d64642b8f938bfc302d99a04e8868dcd6e73793bc57e9bce642c2R5) [[2]](diffhunk://#diff-a8d14bf6a01d64642b8f938bfc302d99a04e8868dcd6e73793bc57e9bce642c2R48) [[3]](diffhunk://#diff-c03ee02048c6df01d8e7b1acf0176334067868f3c14dd6de373d02a7402a5b77R12) [[4]](diffhunk://#diff-c03ee02048c6df01d8e7b1acf0176334067868f3c14dd6de373d02a7402a5b77R32-R34)

* Added a `clearLogs()` method to `VMInstance` to clear logs from all associated streams.

**Log management improvements**

* Improved `ConsoleStream.clear()` to reset the `disableSave` flag and properly close and nullify the log writer, ensuring log files are deleted and log writing state is reset. [[1]](diffhunk://#diff-95826e961c1a2dd4125f5715674036233d48425df82e00e16fff27bc586d7f81R112-R120) [[2]](diffhunk://#diff-95826e961c1a2dd4125f5715674036233d48425df82e00e16fff27bc586d7f81L126-L127)