### PR TITLE
chore(ci): skip re-compression when uploading artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,13 +76,15 @@ jobs:
           echo "name=${ver}" >> "$GITHUB_OUTPUT"
 
       - name: Upload debug APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DroidVM-${{ steps.version.outputs.name }}-debug
           path: app/build/outputs/apk/debug/*.apk
+          archive: false
 
       - name: Upload release APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DroidVM-${{ steps.version.outputs.name }}-release
           path: app/build/outputs/apk/release/*.apk
+          archive: false


### PR DESCRIPTION
- bump actions/upload-artifact to v7
- set archive: false to avoid re-zipping already-compressed apk