### PR TITLE
fix(background download): ADD POST_NOTIFICATIONS 

### DIFF
--- a/app/src/main/java/cn/classfun/droidvm/lib/download/DiskDownloadService.java
+++ b/app/src/main/java/cn/classfun/droidvm/lib/download/DiskDownloadService.java
@@ -151,11 +151,17 @@ public final class DiskDownloadService extends Service {
             }
             switch (p.state) {
                 case DiskDownloadManager.STATE_SUCCESS:
-                    if (nm != null) nm.notify(notifId(id), buildDone(id));
+                    if (nm != null) {
+                        nm.cancel(notifId(id));
+                        nm.notify(doneNotifId(id), buildDone(id));
+                    }
                     active.remove(id);
                     break;
                 case DiskDownloadManager.STATE_FAILED:
-                    if (nm != null) nm.notify(notifId(id), buildFailed(id, p));
+                    if (nm != null) {
+                        nm.cancel(notifId(id));
+                        nm.notify(doneNotifId(id), buildFailed(id, p));
+                    }
                     active.remove(id);
                     break;
                 case DiskDownloadManager.STATE_CANCELLED:
@@ -193,8 +199,11 @@ public final class DiskDownloadService extends Service {
         handler.removeCallbacks(pollTask);
         polling = false;
         foregroundId = -1;
-        // DETACH so finished (success/failed) notifications stay in the shade.
-        stopForeground(STOP_FOREGROUND_DETACH);
+        // REMOVE clears the ongoing foreground notification for good (DETACH
+        // would leave a stuck, un-swipeable notification after a cancel).
+        // Finished downloads carry their own separate notification
+        // (doneNotifId) that this does not touch.
+        stopForeground(STOP_FOREGROUND_REMOVE);
         stopSelf();
     }
 
@@ -322,5 +331,13 @@ public final class DiskDownloadService extends Service {
 
     private static int notifId(long id) {
         return NOTIF_BASE + (int) (id & 0xFFFF);
+    }
+
+    /**
+     * Separate id for a finished (success/failed) notification, so it survives
+     * the ongoing foreground notification being removed when the service stops.
+     */
+    private static int doneNotifId(long id) {
+        return NOTIF_BASE + 0x1_0000 + (int) (id & 0xFFFF);
     }
 }

--- a/app/src/main/java/cn/classfun/droidvm/lib/ui/NotificationPermission.java
+++ b/app/src/main/java/cn/classfun/droidvm/lib/ui/NotificationPermission.java
@@ -1,0 +1,67 @@
+package cn.classfun.droidvm.lib.ui;
+
+import android.Manifest;
+import android.content.pm.PackageManager;
+
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
+import cn.classfun.droidvm.R;
+
+/**
+ * Asks for the runtime POST_NOTIFICATIONS permission (required since Android 13,
+ * the app's minSdk) at the moment a background download is about to start,
+ * after a short rationale. The download proceeds either way -- the permission
+ * only controls whether the foreground-service progress notification is shown.
+ *
+ * Construct from an activity's {@code onCreate}: the result launcher has to be
+ * registered before the activity reaches STARTED.
+ */
+public final class NotificationPermission {
+    private final AppCompatActivity activity;
+    private final ActivityResultLauncher<String> launcher;
+    private Runnable pending;
+
+    public NotificationPermission(@NonNull AppCompatActivity activity) {
+        this.activity = activity;
+        this.launcher = activity.registerForActivityResult(
+            new ActivityResultContracts.RequestPermission(), granted -> runPending());
+    }
+
+    /**
+     * Runs {@code action} immediately when notifications are already allowed;
+     * otherwise shows a rationale, requests the permission, and runs it once the
+     * user has responded (whether or not they granted it).
+     */
+    public void ensureThen(@NonNull Runnable action) {
+        if (granted()) {
+            action.run();
+            return;
+        }
+        pending = action;
+        new MaterialAlertDialogBuilder(activity)
+            .setTitle(R.string.notification_permission_title)
+            .setMessage(R.string.notification_permission_message)
+            .setPositiveButton(R.string.notification_permission_allow,
+                (d, w) -> launcher.launch(Manifest.permission.POST_NOTIFICATIONS))
+            .setNegativeButton(R.string.notification_permission_skip, (d, w) -> runPending())
+            .setOnCancelListener(d -> runPending())
+            .show();
+    }
+
+    private void runPending() {
+        var action = pending;
+        pending = null;
+        if (action != null) action.run();
+    }
+
+    private boolean granted() {
+        return ContextCompat.checkSelfPermission(activity,
+            Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED;
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/ui/disk/download/ImportURLActivity.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/disk/download/ImportURLActivity.java
@@ -47,6 +47,7 @@ import java.util.concurrent.Executors;
 import cn.classfun.droidvm.R;
 import cn.classfun.droidvm.lib.download.DiskDownloadManager;
 import cn.classfun.droidvm.lib.download.DiskDownloadService;
+import cn.classfun.droidvm.lib.ui.NotificationPermission;
 import cn.classfun.droidvm.lib.ui.SimpleTextWatcher;
 import cn.classfun.droidvm.lib.utils.NetUtils.HttpException;
 import cn.classfun.droidvm.ui.disk.create.DiskFormat;
@@ -68,6 +69,7 @@ public final class ImportURLActivity extends AppCompatActivity {
     private KernelAnalysisWidget kernelAnalysis;
     private NestedScrollView scrollView;
     private ExtendedFloatingActionButton fabImport;
+    private NotificationPermission notifPermission;
     private CollapsingToolbarLayout collapsingToolbar;
     private MaterialToolbar toolbar;
     private boolean isLoading = false;
@@ -83,6 +85,7 @@ public final class ImportURLActivity extends AppCompatActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_import_url);
+        notifPermission = new NotificationPermission(this);
         collapsingToolbar = findViewById(R.id.collapsing_toolbar);
         toolbar = findViewById(R.id.toolbar);
         inputUrl = findViewById(R.id.input_url);
@@ -345,7 +348,7 @@ public final class ImportURLActivity extends AppCompatActivity {
         }
         downloadName = name;
         downloadFolder = folder;
-        startDownload(urlStr);
+        notifPermission.ensureThen(() -> startDownload(urlStr));
     }
 
     private void startDownload(String url) {

--- a/app/src/main/java/cn/classfun/droidvm/ui/disk/images/ImportImagesActivity.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/disk/images/ImportImagesActivity.java
@@ -41,6 +41,7 @@ import cn.classfun.droidvm.lib.data.Repos;
 import cn.classfun.droidvm.lib.download.DiskDownloadManager;
 import cn.classfun.droidvm.lib.download.DiskDownloadService;
 import cn.classfun.droidvm.lib.ui.IconItemAdapter;
+import cn.classfun.droidvm.lib.ui.NotificationPermission;
 import cn.classfun.droidvm.ui.disk.create.DiskFormat;
 import cn.classfun.droidvm.ui.widgets.row.DropdownRowWidget;
 import cn.classfun.droidvm.ui.widgets.row.TextInputRowWidget;
@@ -62,6 +63,7 @@ public final class ImportImagesActivity extends AppCompatActivity {
     private TextView tvInfoSize;
     private TextView tvInfoUrl;
     private ExtendedFloatingActionButton fabDownload;
+    private NotificationPermission notifPermission;
     private DownloadWidget downloadWidget;
     private NestedScrollView scrollView;
     private String[] mirrorKeys;
@@ -78,6 +80,7 @@ public final class ImportImagesActivity extends AppCompatActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_import_images);
+        notifPermission = new NotificationPermission(this);
         collapsingToolbar = findViewById(R.id.collapsing_toolbar);
         toolbar = findViewById(R.id.toolbar);
         cardPlaceholder = findViewById(R.id.card_placeholder);
@@ -304,7 +307,7 @@ public final class ImportImagesActivity extends AppCompatActivity {
         downloadName = name;
         downloadFolder = folder;
         var url = resolveDownloadUrl();
-        startDownload(url);
+        notifPermission.ensureThen(() -> startDownload(url));
     }
 
     private void startDownload(String url) {

--- a/app/src/main/java/cn/classfun/droidvm/ui/disk/lxc/ImportLxcImagesActivity.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/disk/lxc/ImportLxcImagesActivity.java
@@ -58,6 +58,7 @@ import cn.classfun.droidvm.lib.data.Repos;
 import cn.classfun.droidvm.lib.download.DiskDownloadManager;
 import cn.classfun.droidvm.lib.download.DiskDownloadService;
 import cn.classfun.droidvm.lib.ui.IconItemAdapter;
+import cn.classfun.droidvm.lib.ui.NotificationPermission;
 import cn.classfun.droidvm.ui.disk.create.DiskFormat;
 import cn.classfun.droidvm.ui.widgets.row.DropdownRowWidget;
 import cn.classfun.droidvm.ui.widgets.row.TextInputRowWidget;
@@ -88,6 +89,7 @@ public final class ImportLxcImagesActivity extends AppCompatActivity {
     private MaterialCardView cardInfo;
     private TextView tvInfoSize, tvInfoPath;
     private ExtendedFloatingActionButton fabImport;
+    private NotificationPermission notifPermission;
     private DownloadWidget downloadWidget;
     private KernelAnalysisWidget kernelAnalysis;
     private NestedScrollView scrollView;
@@ -112,6 +114,7 @@ public final class ImportLxcImagesActivity extends AppCompatActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_import_lxc_images);
+        notifPermission = new NotificationPermission(this);
         collapsingToolbar = findViewById(R.id.collapsing_toolbar);
         toolbar = findViewById(R.id.toolbar);
         dropdownMetaSource = findViewById(R.id.dropdown_meta_source);
@@ -690,7 +693,7 @@ public final class ImportLxcImagesActivity extends AppCompatActivity {
         }
         downloadName = name;
         downloadFolder = folder;
-        startDownload(downloadUrl);
+        notifPermission.ensureThen(() -> startDownload(downloadUrl));
     }
 
     private void startDownload(String url) {

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -933,4 +933,9 @@
     <string name="hugepage_stop_confirm">确定要停止大页预留模块吗？这将释放所有预分配的页面，可能会影响正在运行的虚拟机。</string>
     <string name="hugepage_unloaded">模块已卸载</string>
     <string name="hugepage_unload_failed">卸载模块失败</string>
+
+    <string name="notification_permission_title">允许通知？</string>
+    <string name="notification_permission_message">DroidVM 会在后台下载磁盘镜像，并通过通知显示进度。请允许通知，以便随时查看下载进度。</string>
+    <string name="notification_permission_allow">继续</string>
+    <string name="notification_permission_skip">暂不</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -933,4 +933,9 @@
     <string name="hugepage_stop_confirm">確定要停止大頁預留模組嗎？這將釋放所有預分配的頁面，可能會影響正在執行的虛擬機器。</string>
     <string name="hugepage_unloaded">模組已解除安裝</string>
     <string name="hugepage_unload_failed">解除安裝模組失敗</string>
+
+    <string name="notification_permission_title">允許通知？</string>
+    <string name="notification_permission_message">DroidVM 會在背景下載磁碟映像，並透過通知顯示進度。請允許通知，以便隨時查看下載進度。</string>
+    <string name="notification_permission_allow">繼續</string>
+    <string name="notification_permission_skip">暫不</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -972,4 +972,9 @@
     <string name="hugepage_stop_confirm">Are you sure you want to unload the hugepage reserve module? This will release all pre-allocated pages and may affect running VMs.</string>
     <string name="hugepage_unloaded">Module unloaded</string>
     <string name="hugepage_unload_failed">Failed to unload module</string>
+
+    <string name="notification_permission_title">Allow notifications?</string>
+    <string name="notification_permission_message">DroidVM downloads disk images in the background and shows the progress in a notification. Allow notifications so you can keep an eye on the download.</string>
+    <string name="notification_permission_allow">Continue</string>
+    <string name="notification_permission_skip">Not now</string>
 </resources>


### PR DESCRIPTION
之前的實作背景下載忘記用 POST_NOTIFICATIONS  詢問使用者打開通知權限了  

要手動去設定 打開通知權限才能看下載進度  

這個 PR 補上詢問「DroidVM 會在背景下載磁碟映像，並透過通知顯示進度。請允許通知，以便隨時查看下載進度。」