### PR TITLE
feat(native-display): add native display backend for crosvm

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -83,6 +83,13 @@
             android:windowSoftInputMode="adjustResize" />
 
         <activity
+            android:name=".ui.vm.display.nativedisplay.display.VMNativeDisplayActivity"
+            android:configChanges="orientation|screenSize|keyboardHidden|screenLayout|smallestScreenSize"
+            android:exported="false"
+            android:theme="@style/Theme.DroidVM.NoActionBar.Dark"
+            android:windowSoftInputMode="adjustResize" />
+
+        <activity
             android:name=".ui.disk.lxc.ImportLxcImagesActivity"
             android:configChanges="orientation|screenSize|keyboardHidden|screenLayout|smallestScreenSize"
             android:exported="false"

--- a/app/src/main/aidl/android/crosvm/DisplayConfig.aidl
+++ b/app/src/main/aidl/android/crosvm/DisplayConfig.aidl
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.crosvm;
+
+/** Display configuration reported by crosvm. */
+parcelable DisplayConfig {
+    int width;
+    int height;
+    int dpi;
+    int refreshRate;
+}

--- a/app/src/main/aidl/android/crosvm/ICrosvmAndroidDisplayService.aidl
+++ b/app/src/main/aidl/android/crosvm/ICrosvmAndroidDisplayService.aidl
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.crosvm;
+
+import android.crosvm.DisplayConfig;
+import android.os.ParcelFileDescriptor;
+import android.view.Surface;
+
+/**
+ * Service to provide Crosvm with an Android Surface for showing a guest's display.
+ *
+ * NOTE: This binder is implemented by crosvm itself (android_display_backend). The method order
+ * here MUST match the .aidl crosvm was built against, because binder transaction codes are derived
+ * from declaration order. Input forwarding is NOT done through this interface; input goes through
+ * per-device unix sockets that crosvm reads via `--input ...[path=...]`.
+ */
+interface ICrosvmAndroidDisplayService {
+    void setSurface(in Surface surface, boolean forCursor);
+    void setCursorStream(in ParcelFileDescriptor stream);
+    void removeSurface(boolean forCursor);
+    void saveFrameForSurface(boolean forCursor);
+    void drawSavedFrameForSurface(boolean forCursor);
+
+    /**
+     * Returns the guest display configuration, or null if not available yet. crosvm's current
+     * backend may not implement this; callers must tolerate the call failing and fall back to a
+     * default resolution.
+     */
+    DisplayConfig getDisplayConfig();
+}

--- a/app/src/main/aidl/cn/classfun/droidvm/display/INativeDisplayRootService.aidl
+++ b/app/src/main/aidl/cn/classfun/droidvm/display/INativeDisplayRootService.aidl
@@ -1,0 +1,27 @@
+package cn.classfun.droidvm.display;
+
+/**
+ * AIDL interface for the native-display broker. It is implemented and hosted by the daemon (which
+ * already runs as root) and handed to the UI via a broadcast (see
+ * NativeDisplay.BINDER_BROADCAST_ACTION), because a live IBinder cannot cross the daemon's
+ * TCP/JSON-RPC channel. No separate root process is involved: an untrusted_app can neither look up
+ * crosvm's display service nor connectto the daemon's su-domain input sockets itself, so it calls
+ * these methods on the daemon over binder instead.
+ */
+interface INativeDisplayRootService {
+    /**
+     * Calls ServiceManager.waitForService(serviceName) inside the daemon (root) and returns the
+     * ICrosvmAndroidDisplayService binder, or null if not found. serviceName is the per-VM key.
+     */
+    IBinder waitForDisplayBinder(String serviceName);
+
+    /**
+     * Forwards pre-encoded evdev [data] (8-byte records) for [channel] straight to the crosvm input
+     * socket the daemon owns, looking up the running VM by [vmId]. Runs on a daemon binder thread, so
+     * the bytes reach crosvm with no extra socket hop. Bytes (not an fd) cross the binder,
+     * sidestepping both the SELinux 'connectto' denial (app->su socket) and the 'fd use' denial (app
+     * receiving an su-owned fd). Returns true if written, false on any failure so the caller can fall
+     * back to the vm_input IPC path.
+     */
+    boolean writeInput(String vmId, int channel, in byte[] data);
+}

--- a/app/src/main/java/cn/classfun/droidvm/daemon/Daemon.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/Daemon.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import cn.classfun.droidvm.daemon.display.DaemonSystemContext;
 import cn.classfun.droidvm.daemon.server.Server;
 import cn.classfun.droidvm.lib.natives.UnixHelper;
 import cn.classfun.droidvm.lib.utils.FileUtils;
@@ -99,6 +100,9 @@ public final class Daemon {
     public static void main(String... args) {
         System.out.print("Starting DroidVM Daemon...\n");
         UnixHelper.load();
+        // Build a system Context on the main thread (it prepares the main looper) so the daemon can
+        // broadcast the native-display binder to the UI. Must happen before server.run() blocks here.
+        DaemonSystemContext.init();
         System.out.printf("Current pid: %d\n", Process.myPid());
         Log.d(TAG, "DroidVM Daemon is starting...");
         daemonHash = getMyHash();

--- a/app/src/main/java/cn/classfun/droidvm/daemon/display/DaemonSystemContext.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/display/DaemonSystemContext.java
@@ -1,0 +1,60 @@
+package cn.classfun.droidvm.daemon.display;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.os.Looper;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+
+import java.lang.reflect.Constructor;
+
+/**
+ * Builds a system {@link Context} inside the daemon's bare app_process so it can {@code sendBroadcast}
+ * - the channel used to hand the native-display binder to the UI (a live IBinder can't cross the
+ * daemon's TCP/JSON-RPC socket).
+ *
+ * We construct an {@code ActivityThread} directly and ask it for the system Context, rather than
+ * {@code ActivityThread.systemMain()}: systemMain()'s {@code attach(true)} runs app/Instrumentation
+ * init that throws in a bare daemon process. The ActivityThread ctor only needs a prepared main
+ * looper (for its internal Handler), so {@link #init()} must run on the daemon's main thread (see
+ * Daemon.main). We never loop it; a fire-and-forget broadcast is a plain binder call to AMS.
+ */
+public final class DaemonSystemContext {
+    private static final String TAG = "DaemonSysContext";
+    private static Context context;
+
+    private DaemonSystemContext() {
+    }
+
+    /** Creates the system Context once, on the daemon main thread. Safe to call repeatedly. */
+    @SuppressLint({"PrivateApi", "DiscouragedPrivateApi"})
+    public static synchronized void init() {
+        if (context != null) return;
+        try {
+            if (Looper.myLooper() == null) Looper.prepareMainLooper();
+        } catch (Throwable t) {
+            Log.w(TAG, "prepareMainLooper: " + t);
+        }
+        try {
+            Class<?> at = Class.forName("android.app.ActivityThread");
+            Constructor<?> ctor = at.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            Object thread = ctor.newInstance();
+            context = (Context) at.getMethod("getSystemContext").invoke(thread);
+            if (context != null) {
+                Log.i(TAG, "system context ready");
+                return;
+            }
+            Log.e(TAG, "getSystemContext returned null");
+        } catch (Throwable t) {
+            Log.e(TAG, "failed to create system context", t);
+        }
+    }
+
+    /** The system Context, or null if {@link #init()} hasn't run or failed. */
+    @Nullable
+    public static Context get() {
+        return context;
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/daemon/display/NativeDisplayBinder.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/display/NativeDisplayBinder.java
@@ -1,0 +1,124 @@
+package cn.classfun.droidvm.daemon.display;
+
+import static cn.classfun.droidvm.BuildConfig.APPLICATION_ID;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import java.lang.reflect.Method;
+
+import cn.classfun.droidvm.daemon.server.ServerContext;
+import cn.classfun.droidvm.display.INativeDisplayRootService;
+import cn.classfun.droidvm.lib.store.vm.NativeDisplay;
+
+/**
+ * Daemon-hosted native-display broker. The daemon already runs as root, so it does both jobs the
+ * UI used to reach through a separate libsu RootService:
+ * <ul>
+ *   <li>{@link INativeDisplayRootService#waitForDisplayBinder(String)} - look up the per-VM
+ *       ICrosvmAndroidDisplayService binder crosvm registers via
+ *       {@code --android-display-service <serviceName>} (an untrusted_app can't do this lookup).</li>
+ *   <li>{@link INativeDisplayRootService#writeInput(String, int, byte[])} - write evdev straight to
+ *       the crosvm input socket the daemon owns (no extra socket hop), by looking up the VM.</li>
+ * </ul>
+ *
+ * The binder can't ride the daemon's TCP/JSON-RPC channel, so it is broadcast to the UI through
+ * system_server (see {@link #attach}); the {@code display_attach} IPC command triggers that.
+ */
+public final class NativeDisplayBinder {
+    private static final String TAG = "NativeDisplayBinder";
+
+    private static INativeDisplayRootService.Stub binder;
+
+    private NativeDisplayBinder() {
+    }
+
+    /**
+     * Builds the broker binder once and broadcasts it to the UI Activity that requested it with
+     * [nonce]. Called from the {@code display_attach} IPC handler (a daemon worker thread).
+     */
+    public static synchronized void attach(@NonNull ServerContext ctx, @NonNull String nonce) {
+        if (binder == null) binder = createBinder(ctx);
+        broadcast(binder, nonce);
+    }
+
+    private static INativeDisplayRootService.Stub createBinder(@NonNull ServerContext ctx) {
+        return new INativeDisplayRootService.Stub() {
+            @Override
+            public IBinder waitForDisplayBinder(String serviceName) {
+                return doWaitForDisplayBinder(serviceName);
+            }
+
+            @Override
+            public boolean writeInput(String vmId, int channel, byte[] data) {
+                if (vmId == null || data == null || data.length == 0) return false;
+                var inst = ctx.getVMs().findById(vmId);
+                if (inst == null) return false;
+                return inst.writeNativeInput(channel, data);
+            }
+        };
+    }
+
+    /** Broadcasts [binder] to our package with [nonce] nested in a Bundle (kept off the top-level
+     * extras so AMS doesn't strip the live IBinder). */
+    private static void broadcast(@NonNull IBinder binder, @NonNull String nonce) {
+        var context = DaemonSystemContext.get();
+        if (context == null) {
+            Log.e(TAG, "no system context; cannot broadcast display binder");
+            return;
+        }
+        var bundle = new Bundle();
+        bundle.putBinder(NativeDisplay.EXTRA_BINDER, binder);
+        bundle.putString(NativeDisplay.EXTRA_NONCE, nonce);
+        var intent = new Intent(NativeDisplay.BINDER_BROADCAST_ACTION);
+        intent.setPackage(APPLICATION_ID);
+        intent.putExtra(NativeDisplay.EXTRA_BUNDLE, bundle);
+        context.sendBroadcast(intent);
+        Log.i(TAG, "broadcast native-display binder (nonce=" + nonce + ")");
+    }
+
+    private static IBinder smCall(@NonNull String method, @NonNull String name) {
+        try {
+            Class<?> sm = Class.forName("android.os.ServiceManager");
+            Method m = sm.getMethod(method, String.class);
+            return (IBinder) m.invoke(null, name);
+        } catch (Exception e) {
+            Log.w(TAG, method + " reflection failed: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private static IBinder waitForServiceWithTimeout(@NonNull String name, long timeoutMs) {
+        var holder = new IBinder[1];
+        var t = new Thread(() -> holder[0] = smCall("waitForService", name), "WaitSvc-" + name);
+        t.setDaemon(true);
+        t.start();
+        try {
+            t.join(timeoutMs);
+        } catch (InterruptedException ignored) {
+        }
+        return holder[0];
+    }
+
+    private static IBinder doWaitForDisplayBinder(@NonNull String serviceName) {
+        Log.i(TAG, "waitForDisplayBinder('" + serviceName + "')");
+        var direct = smCall("checkService", serviceName);
+        if (direct != null) {
+            Log.i(TAG, "OK: got display binder directly from ServiceManager");
+            return direct;
+        }
+        Log.i(TAG, "Not found, waiting up to 5s...");
+        var waited = waitForServiceWithTimeout(serviceName, 5000L);
+        if (waited != null) {
+            Log.i(TAG, "OK: got display binder via waitForService");
+            return waited;
+        }
+        Log.e(TAG, "'" + serviceName + "' not found - is crosvm running with "
+            + "--android-display-service " + serviceName + "?");
+        return null;
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/daemon/ipc/vm/DisplayAttachHandler.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/ipc/vm/DisplayAttachHandler.java
@@ -1,0 +1,32 @@
+package cn.classfun.droidvm.daemon.ipc.vm;
+
+import androidx.annotation.NonNull;
+
+import com.google.auto.service.AutoService;
+
+import cn.classfun.droidvm.daemon.display.NativeDisplayBinder;
+import cn.classfun.droidvm.daemon.server.ClientRequest;
+import cn.classfun.droidvm.daemon.server.RequestException;
+import cn.classfun.droidvm.daemon.server.RequestHandler;
+
+/**
+ * Hands the daemon's native-display binder to the UI. A live IBinder can't ride this JSON-RPC
+ * channel, so the daemon broadcasts it (through system_server) to the requesting Activity instead;
+ * the Activity proves which broadcast is its own with [nonce]. Params: nonce (per-attach token).
+ */
+@AutoService(RequestHandler.class)
+public final class DisplayAttachHandler extends RequestHandler {
+    @NonNull
+    @Override
+    public String getName() {
+        return "display_attach";
+    }
+
+    @Override
+    public void handle(@NonNull ClientRequest request) throws Exception {
+        var nonce = request.getParams().optString("nonce", "");
+        if (nonce.isEmpty())
+            throw new RequestException("missing nonce");
+        NativeDisplayBinder.attach(request.getContext(), nonce);
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/daemon/ipc/vm/InputHandler.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/ipc/vm/InputHandler.java
@@ -1,0 +1,44 @@
+package cn.classfun.droidvm.daemon.ipc.vm;
+
+import static cn.classfun.droidvm.lib.utils.StringUtils.fmt;
+
+import android.util.Base64;
+
+import androidx.annotation.NonNull;
+
+import com.google.auto.service.AutoService;
+
+import cn.classfun.droidvm.daemon.server.ClientRequest;
+import cn.classfun.droidvm.daemon.server.RequestException;
+import cn.classfun.droidvm.daemon.server.RequestHandler;
+
+/**
+ * Forwards native-display input from the UI to the per-VM crosvm process. The daemon is the only
+ * listener on crosvm's --input sockets (it pre-binds them before exec'ing crosvm), so it is the
+ * only process that can deliver evdev to the guest; the UI sends bytes here instead of writing a
+ * socket directly. Params: vm_id, channel (NativeDisplay constants), data (base64 evdev records).
+ */
+@AutoService(RequestHandler.class)
+public final class InputHandler extends RequestHandler {
+    @NonNull
+    @Override
+    public String getName() {
+        return "vm_input";
+    }
+
+    @Override
+    public void handle(@NonNull ClientRequest request) throws Exception {
+        var params = request.getParams();
+        var vmId = params.optString("vm_id", "");
+        if (vmId.isEmpty())
+            throw new RequestException("missing vm_id");
+        var channel = params.optInt("channel", -1);
+        var data = Base64.decode(params.optString("data", ""), Base64.NO_WRAP);
+        var inst = request.getContext().getVMs().findById(vmId);
+        if (inst == null)
+            throw new RequestException(fmt("VM not found: %s", vmId));
+        // Report whether the bytes actually reached crosvm so the UI can tell a silent drop (peer
+        // not connected yet, bad channel, VM not running) from a real delivery.
+        request.res().put("delivered", inst.writeNativeInput(channel, data));
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/daemon/server/Server.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/server/Server.java
@@ -146,6 +146,9 @@ public final class Server {
 
     private void handleClient(@NonNull Socket client) {
         try {
+            // Disable Nagle on the accepted socket so daemon->UI responses (incl. input ACKs)
+            // aren't delayed; pairs with the client-side setTcpNoDelay in DaemonClient.
+            client.setTcpNoDelay(true);
             var handler = new ClientHandler(this, client);
             synchronized (clients) {
                 clients.add(handler);

--- a/app/src/main/java/cn/classfun/droidvm/daemon/vm/VMBackendInstance.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/vm/VMBackendInstance.java
@@ -25,6 +25,14 @@ public abstract class VMBackendInstance {
 
     public abstract void cleanup();
 
+    /**
+     * Writes pre-encoded evdev bytes to the running backend's native-display input channel on
+     * behalf of the UI. Only the crosvm backend implements this; others report not-delivered.
+     */
+    public boolean writeNativeInput(int channel, @NonNull byte[] data) {
+        return false;
+    }
+
     @NonNull
     @SuppressWarnings("unused")
     public Map<String, ConsoleStream> getStreams() {

--- a/app/src/main/java/cn/classfun/droidvm/daemon/vm/VMInstance.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/vm/VMInstance.java
@@ -75,10 +75,18 @@ public final class VMInstance extends VMConfig {
     }
 
     @NonNull
-    VMBackendInstance getBackendInstance() {
+    synchronized VMBackendInstance getBackendInstance() {
         if (this.backendInstance == null)
             this.backendInstance = getBackend().create(this);
         return this.backendInstance;
+    }
+
+    /** Forwards UI-sent evdev bytes to the running backend's native-display input channel. */
+    public boolean writeNativeInput(int channel, @NonNull byte[] data) {
+        // Only a running VM has a backend with bound input sockets; skip otherwise so a stale or
+        // spoofed input call can't lazily create an idle backend instance.
+        if (state != VMState.RUNNING) return false;
+        return getBackendInstance().writeNativeInput(channel, data);
     }
 
     @NonNull

--- a/app/src/main/java/cn/classfun/droidvm/daemon/vm/backend/CrosvmBackendInstance.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/vm/backend/CrosvmBackendInstance.java
@@ -36,6 +36,7 @@ import cn.classfun.droidvm.lib.store.disk.DiskBus;
 import cn.classfun.droidvm.lib.store.vm.DisplayBackend;
 import cn.classfun.droidvm.lib.store.vm.GpuApi;
 import cn.classfun.droidvm.lib.store.vm.GpuBackend;
+import cn.classfun.droidvm.lib.store.vm.NativeDisplay;
 import cn.classfun.droidvm.lib.store.vm.ProtectedVM;
 import cn.classfun.droidvm.lib.store.vm.SharedDirCache;
 import cn.classfun.droidvm.lib.store.vm.SharedDirType;
@@ -48,6 +49,8 @@ public final class CrosvmBackendInstance extends VMBackendInstance {
     private final VMConfig config;
     private SerialPipe uart = null;
     private String controlSocketPath = null;
+    /** Owns the per-VM native-display input sockets (crosvm-facing + UI-facing); see start(). */
+    private final NativeDisplayInputBridge inputBridge = new NativeDisplayInputBridge();
     private final FDPipeConsoleStream uartStream;
     private final InputConsoleStream stdoutStream;
     private final InputConsoleStream stderrStream;
@@ -85,6 +88,16 @@ public final class CrosvmBackendInstance extends VMBackendInstance {
         controlSocketPath = pathJoin(RUN_PATH, fmt("%s.sock", config.getName()));
         deleteFile(controlSocketPath);
         Log.i(TAG, fmt("Control socket path: %s", controlSocketPath));
+        // Native display: crosvm's --input <kind>[path=...] connects to a unix socket whose inode
+        // must already exist (crosvm is the *client*), and the display-page entry only appears after
+        // the VM is up - so the daemon is the only process that can both bind the socket before
+        // crosvm starts and stay alive to feed it. We pre-bind + accept here; the UI forwards evdev
+        // to us via the vm_input IPC command (see InputHandler). Server fds released on cleanup().
+        if (isNativeDisplayEnabled()) {
+            if (!inputBridge.startListening(NativeDisplay.serviceName(config))) {
+                Log.e(TAG, "Native display input sockets unavailable; crosvm will likely fail");
+            }
+        }
         var args = buildCommand();
         Log.i(TAG, fmt("Executing: %s", String.join(" ", args)));
         try {
@@ -107,6 +120,7 @@ public final class CrosvmBackendInstance extends VMBackendInstance {
                 uart = null;
             }
             controlSocketPath = null;
+            inputBridge.release();
             return result;
         }
         return result;
@@ -309,6 +323,46 @@ public final class CrosvmBackendInstance extends VMBackendInstance {
                 item.optLong("display_height", 720)
             ));
         }
+        // Native display: crosvm registers an ICrosvmAndroidDisplayService binder under a per-VM
+        // name and renders the gfxstream/virtio-gpu output straight into the Android Surface the UI
+        // hands it. Requires the GPU (virtio-gpu) path above. Touch/keyboard come back over the
+        // per-VM unix sockets the root service listens on; their paths must match NativeDisplay.
+        // Single source of truth for the enable check; isNativeDisplayEnabled() also gates the
+        // socket pre-bind in start(), so the two must never diverge.
+        if (isNativeDisplayEnabled()) {
+            buildNativeDisplayCommand(args);
+        }
+    }
+
+    private void buildNativeDisplayCommand(@NonNull List<String> args) {
+        var item = config.item;
+        var serviceName = NativeDisplay.serviceName(config);
+        var width = item.optLong("display_width", 1280);
+        var height = item.optLong("display_height", 720);
+        args.add("--android-display-service");
+        args.add(serviceName);
+        // multi-touch ABS range must equal the guest resolution so view coords scale straight onto
+        // ABS_X/ABS_Y (see EvdevEncoder / TouchScaleCalculator).
+        args.add("--input");
+        args.add(fmt(
+            "multi-touch[path=%s,width=%d,height=%d]",
+            NativeDisplay.inputSocketPath(serviceName, NativeDisplay.MULTITOUCH), width, height
+        ));
+        args.add("--input");
+        args.add(fmt(
+            "keyboard[path=%s]",
+            NativeDisplay.inputSocketPath(serviceName, NativeDisplay.KEYBOARD)
+        ));
+    }
+
+    /** True iff the per-VM crosvm command will reference native-display input sockets. */
+    private boolean isNativeDisplayEnabled() {
+        var item = config.item;
+        if (!item.optBoolean("gpu_enabled", false)) return false;
+        if (!item.optBoolean("display_enabled", false)) return false;
+        var backend = optEnum(item, "display_backend", DisplayBackend.NONE);
+        if (backend != DisplayBackend.VIRTIO_GPU) return false;
+        return item.optBoolean("native_display_enabled", false);
     }
 
     private void buildVncCommand(@NonNull List<String> args) {
@@ -405,10 +459,16 @@ public final class CrosvmBackendInstance extends VMBackendInstance {
     }
 
     @Override
+    public boolean writeNativeInput(int channel, @NonNull byte[] data) {
+        return inputBridge.writeNativeInput(channel, data);
+    }
+
+    @Override
     public void cleanup() {
         if (controlSocketPath != null) {
             deleteFile(controlSocketPath);
             controlSocketPath = null;
         }
+        inputBridge.release();
     }
 }

--- a/app/src/main/java/cn/classfun/droidvm/daemon/vm/backend/NativeDisplayInputBridge.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/vm/backend/NativeDisplayInputBridge.java
@@ -1,0 +1,194 @@
+package cn.classfun.droidvm.daemon.vm.backend;
+
+import static cn.classfun.droidvm.lib.utils.FileUtils.deleteFile;
+import static cn.classfun.droidvm.lib.utils.StringUtils.fmt;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import java.io.IOException;
+
+import cn.classfun.droidvm.lib.natives.UnixHelper;
+import cn.classfun.droidvm.lib.network.FDSocket;
+import cn.classfun.droidvm.lib.store.vm.NativeDisplay;
+
+/**
+ * Owns the per-VM native-display input sockets for one crosvm instance. crosvm's --input
+ * <kind>[path=...] connects to a unix socket whose inode must already exist (crosvm is the
+ * *client*), so the daemon is the only process that can both bind the socket before crosvm starts
+ * and stay alive to feed it. This bridge pre-binds + accepts the crosvm-facing sockets; evdev from
+ * the UI arrives via {@link #writeNativeInput(int, byte[])} - called either on the daemon's
+ * native-display broker binder thread (touch hot path) or from the vm_input IPC handler - and is
+ * written straight to the matching crosvm peer. {@link CrosvmBackendInstance} drives the lifecycle:
+ * {@link #startListening(String)} from start() and {@link #release()} from cleanup().
+ */
+final class NativeDisplayInputBridge {
+    private static final String TAG = "NativeDisplayInput";
+
+    /** Server fds for the per-VM native-display input sockets, kept while crosvm is running. */
+    private volatile int[] inputServerFds = null;
+    /** Paths of the input sockets we listened on, so {@link #release()} can unlink them. */
+    private volatile String[] inputSocketPaths = null;
+    /**
+     * The crosvm-side connection accepted on each input channel. crosvm connects to OUR socket at
+     * startup (we are the only listener), so writing UI-forwarded evdev here is what actually
+     * reaches the guest. Indexed by NativeDisplay channel constants. Volatile because the accept
+     * threads, the write threads, and release() all touch it without a single shared lock.
+     */
+    private volatile FDSocket[] inputPeers = null;
+    /** Per-channel write lock; also guards swapping {@link #inputPeers} on reconnect. */
+    private volatile Object[] inputWriteLocks = null;
+    private volatile boolean inputClosed = false;
+
+    /**
+     * Pre-creates the per-VM native-display input sockets as listening unix sockets. crosvm
+     * connects to these paths at startup, so a listener must exist before
+     * {@link CrosvmBackendInstance#start()} execs the crosvm process. nativeUnixListen unlinks any
+     * stale inode and re-binds, so a leftover socket file from a crashed run is replaced rather than
+     * blocking us. Returns true iff every channel ended up with a live listener. Server fds we open
+     * are tracked for release in {@link #release()}.
+     */
+    boolean startListening(@NonNull String serviceName) {
+        if (!UnixHelper.isLoaded()) {
+            Log.w(TAG, "UnixHelper not loaded; cannot pre-bind native-display input sockets");
+            return false;
+        }
+        var paths = new String[NativeDisplay.CHANNEL_COUNT];
+        var fds = new int[NativeDisplay.CHANNEL_COUNT];
+        inputClosed = false;
+        inputPeers = new FDSocket[NativeDisplay.CHANNEL_COUNT];
+        inputWriteLocks = new Object[NativeDisplay.CHANNEL_COUNT];
+        boolean allListening = true;
+        for (int ch = 0; ch < NativeDisplay.CHANNEL_COUNT; ch++) {
+            inputWriteLocks[ch] = new Object();
+            var path = NativeDisplay.inputSocketPath(serviceName, ch);
+            paths[ch] = path;
+            var fd = UnixHelper.nativeUnixListen(path);
+            if (fd < 0) {
+                Log.w(TAG, fmt("Failed to pre-listen on input socket: %s", path));
+                allListening = false;
+                fds[ch] = -1;
+            } else {
+                Log.i(TAG, fmt("Pre-listening on input socket: %s (fd=%d)", path, fd));
+                fds[ch] = fd;
+                // Accept crosvm's connection in the background. crosvm is the client and connects
+                // at its own startup, so a peer may not arrive until after start() execs it.
+                startInputAcceptThread(ch, fd);
+            }
+        }
+        inputSocketPaths = paths;
+        inputServerFds = fds;
+        return allListening;
+    }
+
+    /**
+     * Accepts crosvm's connection on one input channel and keeps the live peer in
+     * {@link #inputPeers}. Loops so a crosvm restart (new connection on the same socket) replaces
+     * the dead peer; ends when {@link #release()} closes the server fd.
+     */
+    private void startInputAcceptThread(int channel, int serverFd) {
+        var t = new Thread(() -> {
+            while (!inputClosed) {
+                int peerFd = UnixHelper.nativeUnixAccept(serverFd);
+                if (peerFd < 0) {
+                    if (inputClosed) break;
+                    try {
+                        Thread.sleep(200);
+                    } catch (InterruptedException e) {
+                        break;
+                    }
+                    continue;
+                }
+                var peer = new FDSocket(peerFd);
+                // Snapshot the lock/peer arrays: release() can null them concurrently.
+                var locks = inputWriteLocks;
+                if (locks == null) {
+                    peer.close();
+                    break;
+                }
+                synchronized (locks[channel]) {
+                    var peers = inputPeers;
+                    if (peers == null) {
+                        peer.close();
+                        break;
+                    }
+                    var old = peers[channel];
+                    peers[channel] = peer;
+                    if (old != null) old.close();
+                }
+                Log.i(TAG, fmt("crosvm input connected: channel %d", channel));
+            }
+        }, fmt("CrosvmInputAccept-%d", channel));
+        t.setDaemon(true);
+        t.start();
+    }
+
+    /**
+     * Writes pre-encoded evdev bytes (8-byte records) to the crosvm connection for [channel].
+     * Called from the daemon IPC thread on behalf of the UI. Returns false if no crosvm peer is
+     * connected yet or the write fails.
+     */
+    boolean writeNativeInput(int channel, @NonNull byte[] data) {
+        if (channel < 0 || channel >= NativeDisplay.CHANNEL_COUNT || data.length == 0) return false;
+        // Snapshot the arrays once: release() nulls these fields concurrently, so dereferencing the
+        // live field after the guard could NPE. The lock object itself stays valid for the session.
+        var locks = inputWriteLocks;
+        if (locks == null) return false;
+        var lock = locks[channel];
+        if (lock == null) return false;
+        synchronized (lock) {
+            var peers = inputPeers;
+            if (peers == null) return false;
+            var peer = peers[channel];
+            if (peer == null || !peer.isOpen()) return false;
+            try {
+                var os = peer.getOutputStream();
+                os.write(data);
+                os.flush();
+                return true;
+            } catch (IOException e) {
+                Log.w(TAG, fmt("input write channel %d failed: %s", channel, e.getMessage()));
+                peers[channel] = null;
+                peer.close();
+                return false;
+            }
+        }
+    }
+
+    /**
+     * Closes the input server fds we opened and unlinks only the inodes we own. Channels that
+     * fell through to the UI's listener (fd == -1) are left untouched so we don't yank a socket
+     * the UI still holds.
+     */
+    void release() {
+        inputClosed = true; // stop accept loops; closing the server fd below unblocks nativeUnixAccept
+        if (inputPeers != null) {
+            for (int ch = 0; ch < inputPeers.length; ch++) {
+                if (inputWriteLocks != null && inputWriteLocks[ch] != null) {
+                    synchronized (inputWriteLocks[ch]) {
+                        if (inputPeers[ch] != null) {
+                            inputPeers[ch].close();
+                            inputPeers[ch] = null;
+                        }
+                    }
+                }
+            }
+            inputPeers = null;
+        }
+        inputWriteLocks = null;
+        if (inputServerFds == null) {
+            inputSocketPaths = null;
+            return;
+        }
+        for (int ch = 0; ch < inputServerFds.length; ch++) {
+            int fd = inputServerFds[ch];
+            if (fd < 0) continue;
+            UnixHelper.nativeCloseFd(fd);
+            if (inputSocketPaths != null && inputSocketPaths[ch] != null)
+                deleteFile(inputSocketPaths[ch]);
+        }
+        inputServerFds = null;
+        inputSocketPaths = null;
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/lib/store/vm/NativeDisplay.java
+++ b/app/src/main/java/cn/classfun/droidvm/lib/store/vm/NativeDisplay.java
@@ -1,0 +1,72 @@
+package cn.classfun.droidvm.lib.store.vm;
+
+import static cn.classfun.droidvm.lib.Constants.DATA_DIR;
+import static cn.classfun.droidvm.lib.utils.StringUtils.fmt;
+import static cn.classfun.droidvm.lib.utils.StringUtils.pathJoin;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Shared naming for the native (crosvm android-display) backend. The daemon (launching crosvm and
+ * hosting the native-display binder) and the UI (looking up the display binder / sending input)
+ * both derive the per-VM service name and socket paths from here, so they agree and different VMs
+ * never collide.
+ *
+ * The service name doubles as the vmKey: it identifies both the servicemanager entry crosvm
+ * registers (--android-display-service) and the VM's input-socket set.
+ */
+public final class NativeDisplay {
+    /** Input channels (MVP: multi-touch + keyboard). */
+    public static final int MULTITOUCH = 0;
+    public static final int KEYBOARD = 1;
+    public static final int CHANNEL_COUNT = 2;
+
+    /**
+     * Broadcast the daemon (running as root) sends to hand its INativeDisplayRootService binder to
+     * the UI. A live IBinder can't cross the daemon's TCP/JSON-RPC channel, so it travels through
+     * system_server as a broadcast extra instead (the same path libsu/Shizuku use), sidestepping the
+     * servicemanager-find restriction an untrusted_app hits. The binder + nonce are nested in a
+     * Bundle under {@link #EXTRA_BUNDLE} so AMS doesn't strip the binder from the top-level extras.
+     */
+    public static final String BINDER_BROADCAST_ACTION =
+        "cn.classfun.droidvm.action.NATIVE_DISPLAY_BINDER";
+    public static final String EXTRA_BUNDLE = "extra.bundle";
+    public static final String EXTRA_BINDER = "binder";
+    /** Per-attach random token; the UI only accepts a broadcast carrying the nonce it requested. */
+    public static final String EXTRA_NONCE = "nonce";
+
+    private static final String[] KINDS = {"multitouch", "keyboard"};
+    private static final String RUN_PATH = pathJoin(DATA_DIR, "run");
+
+    private NativeDisplay() {
+    }
+
+    /** Per-VM crosvm display service name; also used as the vmKey for input sockets. */
+    @NonNull
+    public static String serviceName(@NonNull VMConfig config) {
+        return serviceNameFromId(config.getId().toString());
+    }
+
+    /** Same as {@link #serviceName(VMConfig)} but from a raw VM id (e.g. an Intent extra). */
+    @NonNull
+    public static String serviceNameFromId(@NonNull String vmId) {
+        return "droidvm_disp_" + sanitize(vmId);
+    }
+
+    /** The socket path crosvm connects to for [vmKey]'s [channel]. Must match across all callers. */
+    @NonNull
+    public static String inputSocketPath(@NonNull String vmKey, int channel) {
+        return pathJoin(RUN_PATH, fmt("%s_input_%s.sock", sanitize(vmKey), KINDS[channel]));
+    }
+
+    /** Keep socket/service names to a filesystem- and binder-safe charset. */
+    @NonNull
+    public static String sanitize(@NonNull String s) {
+        var sb = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            sb.append((Character.isLetterOrDigit(c) || c == '_' || c == '-') ? c : '_');
+        }
+        return sb.toString();
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/display/base/BaseExtraKeysAdapter.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/display/base/BaseExtraKeysAdapter.java
@@ -1,0 +1,123 @@
+package cn.classfun.droidvm.ui.vm.display.base;
+
+import static android.view.KeyEvent.KEYCODE_ALT_LEFT;
+import static android.view.KeyEvent.KEYCODE_CTRL_LEFT;
+import static android.view.KeyEvent.KEYCODE_META_LEFT;
+import static android.view.KeyEvent.KEYCODE_SHIFT_LEFT;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Shared sticky-modifier state machine for the {@link DisplayExtraKeysPanel}. It bridges the
+ * panel's Ctrl/Alt/Shift/Win toggles (sticky vs. one-shot) to a backend; the VNC and native-display
+ * adapters differ only in {@link #emitKey} (how a key reaches the backend) and {@link #isReady}
+ * (whether the backend can accept events), so everything else lives here once.
+ */
+public abstract class BaseExtraKeysAdapter implements KeyListener {
+    @NonNull
+    protected final DisplayExtraKeysPanel panel;
+
+    private boolean ctrlSticky, altSticky, shiftSticky, winSticky;
+
+    protected BaseExtraKeysAdapter(@NonNull DisplayExtraKeysPanel panel) {
+        this.panel = panel;
+        panel.setKeyListener(this);
+    }
+
+    /** Sends one key down/up to the backend. Only invoked when {@link #isReady()} is true. */
+    protected abstract void emitKey(int androidKeyCode, boolean down);
+
+    /** True when the backend can currently accept events. */
+    protected abstract boolean isReady();
+
+    /** True if any active modifier is non-sticky and so must be wrapped around a real keystroke. */
+    public boolean hasNonStickyModifiers() {
+        return (panel.isCtrlDown() && !ctrlSticky)
+            || (panel.isAltDown() && !altSticky)
+            || (panel.isShiftDown() && !shiftSticky)
+            || (panel.isWinDown() && !winSticky);
+    }
+
+    /** Press (or release) every active, non-sticky modifier around a keystroke. */
+    public void applyModifiers(boolean down) {
+        if (!isReady()) return;
+        if (panel.isCtrlDown() && !ctrlSticky) emitKey(KEYCODE_CTRL_LEFT, down);
+        if (panel.isAltDown() && !altSticky) emitKey(KEYCODE_ALT_LEFT, down);
+        if (panel.isShiftDown() && !shiftSticky) emitKey(KEYCODE_SHIFT_LEFT, down);
+        if (panel.isWinDown() && !winSticky) emitKey(KEYCODE_META_LEFT, down);
+        if (!down) {
+            if (!ctrlSticky) panel.setCtrlDown(false);
+            if (!altSticky) panel.setAltDown(false);
+            if (!shiftSticky) panel.setShiftDown(false);
+            if (!winSticky) panel.setWinDown(false);
+            panel.updateToggleButtons();
+        }
+    }
+
+    /** Taps a key with the active modifiers wrapped around it. */
+    protected void tapKey(int androidKeyCode) {
+        if (!isReady()) return;
+        applyModifiers(true);
+        emitKey(androidKeyCode, true);
+        emitKey(androidKeyCode, false);
+        applyModifiers(false);
+    }
+
+    @Override
+    public void onModifierClick(int androidKeyCode) {
+        if (getSticky(androidKeyCode)) {
+            setSticky(androidKeyCode, false);
+            setDown(androidKeyCode, false);
+            if (isReady()) emitKey(androidKeyCode, false);
+        } else {
+            setDown(androidKeyCode, !getDown(androidKeyCode));
+        }
+        panel.updateToggleButtons();
+    }
+
+    @Override
+    public void onModifierLongClick(int androidKeyCode) {
+        setDown(androidKeyCode, true);
+        setSticky(androidKeyCode, true);
+        if (isReady()) emitKey(androidKeyCode, true);
+        panel.updateToggleButtons();
+    }
+
+    private boolean getDown(int keyCode) {
+        switch (keyCode) {
+            case KEYCODE_CTRL_LEFT: return panel.isCtrlDown();
+            case KEYCODE_ALT_LEFT: return panel.isAltDown();
+            case KEYCODE_SHIFT_LEFT: return panel.isShiftDown();
+            case KEYCODE_META_LEFT: return panel.isWinDown();
+            default: return false;
+        }
+    }
+
+    private void setDown(int keyCode, boolean value) {
+        switch (keyCode) {
+            case KEYCODE_CTRL_LEFT: panel.setCtrlDown(value); break;
+            case KEYCODE_ALT_LEFT: panel.setAltDown(value); break;
+            case KEYCODE_SHIFT_LEFT: panel.setShiftDown(value); break;
+            case KEYCODE_META_LEFT: panel.setWinDown(value); break;
+        }
+    }
+
+    private boolean getSticky(int keyCode) {
+        switch (keyCode) {
+            case KEYCODE_CTRL_LEFT: return ctrlSticky;
+            case KEYCODE_ALT_LEFT: return altSticky;
+            case KEYCODE_SHIFT_LEFT: return shiftSticky;
+            case KEYCODE_META_LEFT: return winSticky;
+            default: return false;
+        }
+    }
+
+    private void setSticky(int keyCode, boolean value) {
+        switch (keyCode) {
+            case KEYCODE_CTRL_LEFT: ctrlSticky = value; break;
+            case KEYCODE_ALT_LEFT: altSticky = value; break;
+            case KEYCODE_SHIFT_LEFT: shiftSticky = value; break;
+            case KEYCODE_META_LEFT: winSticky = value; break;
+        }
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/display/nativedisplay/display/DisplayProvider.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/display/nativedisplay/display/DisplayProvider.java
@@ -1,0 +1,225 @@
+package cn.classfun.droidvm.ui.vm.display.nativedisplay.display;
+
+import android.crosvm.DisplayConfig;
+import android.crosvm.ICrosvmAndroidDisplayService;
+import android.os.DeadObjectException;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Looper;
+import android.os.RemoteException;
+import android.util.Log;
+import android.view.Surface;
+import android.view.SurfaceHolder;
+import android.view.SurfaceView;
+
+import androidx.annotation.NonNull;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Hands crosvm the main display {@link Surface} for one VM. MVP: main surface only (no cursor
+ * overlay). gfxstream/virtio-gpu renders the guest framebuffer straight into this Surface.
+ *
+ * Invariants (mirrored from the reference DisplayProvider):
+ *  - Binder fetch on a background thread; the main thread never blocks.
+ *  - setSurface is called AT MOST ONCE per surface lifetime (surfaceCreated -> surfaceDestroyed).
+ *    Layout-driven surfaceChanged must NOT re-call it (crosvm throws if called twice).
+ *  - surfaceDestroyed -> save frame + removeSurface; the next surfaceCreated starts a new session.
+ */
+final class DisplayProvider {
+    private static final String TAG = "NativeDisplayProvider";
+    // Stop polling for the display binder after this many 1s rounds (the daemon-side
+    // waitForService already blocks up to 5s each), so a dead broker doesn't spin forever.
+    private static final int MAX_BINDER_ATTEMPTS = 30;
+
+    private final SurfaceView mainView;
+    private int width;
+    private int height;
+    private final Supplier<IBinder> binderProvider;
+    private final Consumer<Boolean> onConnected;
+    private final Consumer<DisplayConfig> onDisplayConfig;
+
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private final ExecutorService executor =
+        Executors.newSingleThreadExecutor(r -> new Thread(r, "NativeDisplayProvider-bg"));
+
+    // All fields below touched only on the main thread.
+    private ICrosvmAndroidDisplayService displayService;
+    private boolean needsSend = false;
+    private boolean hasSavedFrame = false;
+
+    private final IBinder.DeathRecipient deathRecipient;
+
+    DisplayProvider(@NonNull SurfaceView mainView, int width, int height,
+                    @NonNull Supplier<IBinder> binderProvider,
+                    @NonNull Consumer<Boolean> onConnected,
+                    @NonNull Consumer<DisplayConfig> onDisplayConfig) {
+        this.mainView = mainView;
+        this.width = width;
+        this.height = height;
+        this.binderProvider = binderProvider;
+        this.onConnected = onConnected;
+        this.onDisplayConfig = onDisplayConfig;
+        this.deathRecipient = () -> mainHandler.post(() -> {
+            Log.w(TAG, "display service died - connection lost");
+            onConnected.accept(false);
+            displayService = null;
+            needsSend = false;
+        });
+
+        mainView.setSurfaceLifecycle(SurfaceView.SURFACE_LIFECYCLE_FOLLOWS_ATTACHMENT);
+        mainView.getHolder().addCallback(new Callback());
+
+        var surface = mainView.getHolder().getSurface();
+        if (surface != null && surface.isValid()) {
+            mainView.getHolder().setFixedSize(width, height);
+            needsSend = true;
+        }
+        fetchBinder();
+    }
+
+    private void fetchBinder() {
+        executor.submit(() -> {
+            IBinder binder = null;
+            int attempts = 0;
+            while (!Thread.currentThread().isInterrupted() && attempts < MAX_BINDER_ATTEMPTS) {
+                try {
+                    binder = binderProvider.get();
+                } catch (Exception e) {
+                    Log.e(TAG, "binderProvider threw", e);
+                    binder = null;
+                }
+                if (binder != null) break;
+                attempts++;
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+            final IBinder got = binder;
+            if (got == null) {
+                // Give up rather than poll forever: the daemon broker may have died (the supplier
+                // returns null once rootService is dropped), so the display can't be reached.
+                Log.e(TAG, "display binder unavailable after " + MAX_BINDER_ATTEMPTS + " attempts");
+                mainHandler.post(() -> onConnected.accept(false));
+                return;
+            }
+            mainHandler.post(() -> onBinderReady(got));
+        });
+    }
+
+    private void onBinderReady(@NonNull IBinder binder) {
+        Log.i(TAG, "got crosvm display binder");
+        displayService = ICrosvmAndroidDisplayService.Stub.asInterface(binder);
+        try {
+            binder.linkToDeath(deathRecipient, 0);
+        } catch (RemoteException e) {
+            Log.w(TAG, "linkToDeath failed", e);
+        }
+        try {
+            DisplayConfig config = displayService.getDisplayConfig();
+            if (config != null && config.width > 0 && config.height > 0) {
+                width = config.width;
+                height = config.height;
+                mainView.getHolder().setFixedSize(width, height);
+                onDisplayConfig.accept(config);
+            }
+        } catch (Exception e) {
+            Log.w(TAG, "getDisplayConfig unavailable, using default " + width + "x" + height);
+        }
+        onConnected.accept(true);
+        applyPendingSurface();
+    }
+
+    private void applyPendingSurface() {
+        if (displayService == null || !needsSend) return;
+        trySendSurface(mainView.getHolder());
+    }
+
+    private void trySendSurface(@NonNull SurfaceHolder holder) {
+        var svc = displayService;
+        if (svc == null) return;
+        Surface surface = holder.getSurface();
+        if (surface == null || !surface.isValid()) {
+            Log.w(TAG, "main surface not valid - skipping");
+            return;
+        }
+        try {
+            svc.setSurface(surface, false);
+            markSent();
+        } catch (IllegalArgumentException e) {
+            // KNOWN/BENIGN: the reference TerminalApp DisplayProvider documents that setSurface
+            // throws IllegalArgumentException from the binder reply path even though crosvm DID
+            // receive and configure the surface. Treat as delivered.
+            Log.w(TAG, "setSurface: IllegalArgumentException (known/benign) - treating as delivered");
+            markSent();
+        } catch (Exception e) {
+            Log.e(TAG, "setSurface failed", e);
+        }
+    }
+
+    private void markSent() {
+        needsSend = false;
+        Log.i(TAG, "main surface sent");
+        if (hasSavedFrame && displayService != null) {
+            // The surface was recreated (e.g. rotation/fullscreen). Repaint the captured frame so
+            // a lazy-redraw guest compositor doesn't leave it black.
+            try {
+                displayService.drawSavedFrameForSurface(false);
+            } catch (Exception e) {
+                Log.w(TAG, "drawSavedFrameForSurface failed", e);
+            }
+        }
+    }
+
+    private final class Callback implements SurfaceHolder.Callback {
+        @Override
+        public void surfaceCreated(@NonNull SurfaceHolder holder) {
+            holder.setFixedSize(width, height);
+            needsSend = true; // fresh surface - send on next surfaceChanged
+        }
+
+        @Override
+        public void surfaceChanged(@NonNull SurfaceHolder holder, int format, int w, int h) {
+            if (displayService == null || !needsSend) return;
+            trySendSurface(holder);
+        }
+
+        @Override
+        public void surfaceDestroyed(@NonNull SurfaceHolder holder) {
+            needsSend = false;
+            var svc = displayService;
+            if (svc == null) return;
+            try {
+                svc.saveFrameForSurface(false);
+                hasSavedFrame = true;
+            } catch (Exception e) {
+                Log.w(TAG, "saveFrameForSurface failed", e);
+            }
+            try {
+                svc.removeSurface(false);
+            } catch (DeadObjectException e) {
+                Log.w(TAG, "display service already dead on surfaceDestroyed");
+            } catch (RemoteException e) {
+                Log.e(TAG, "removeSurface failed", e);
+            }
+        }
+    }
+
+    void shutdown() {
+        if (displayService != null) {
+            try {
+                displayService.asBinder().unlinkToDeath(deathRecipient, 0);
+            } catch (Exception ignored) {
+            }
+        }
+        executor.shutdownNow();
+        displayService = null;
+        needsSend = false;
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/display/nativedisplay/display/VMNativeDisplayActivity.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/display/nativedisplay/display/VMNativeDisplayActivity.java
@@ -1,0 +1,514 @@
+package cn.classfun.droidvm.ui.vm.display.nativedisplay.display;
+
+import static android.view.Gravity.CENTER;
+import static android.view.View.GONE;
+import static android.view.View.VISIBLE;
+import static android.view.WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE;
+import static cn.classfun.droidvm.lib.utils.StringUtils.fmt;
+
+import android.annotation.SuppressLint;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.graphics.drawable.GradientDrawable;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Looper;
+import android.os.RemoteException;
+import android.util.Base64;
+import android.util.Log;
+import android.view.KeyCharacterMap;
+import android.view.KeyEvent;
+import android.view.MenuItem;
+import android.view.MotionEvent;
+import android.view.SurfaceView;
+import android.view.View;
+import android.view.WindowInsets;
+import android.view.WindowManager;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.google.android.material.appbar.MaterialToolbar;
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
+import org.json.JSONObject;
+
+import java.util.UUID;
+
+import cn.classfun.droidvm.R;
+import cn.classfun.droidvm.display.INativeDisplayRootService;
+import cn.classfun.droidvm.lib.daemon.DaemonConnection;
+import cn.classfun.droidvm.lib.store.vm.NativeDisplay;
+import cn.classfun.droidvm.lib.ui.DragTouchListener;
+import cn.classfun.droidvm.lib.ui.MaterialMenu;
+import cn.classfun.droidvm.ui.vm.display.base.DisplayExtraKeysPanel;
+import cn.classfun.droidvm.ui.vm.display.nativedisplay.input.DirectInputSink;
+import cn.classfun.droidvm.ui.vm.display.nativedisplay.input.InputForwarder;
+import cn.classfun.droidvm.ui.vm.display.nativedisplay.input.NativeExtraKeysPanel;
+import cn.classfun.droidvm.ui.vm.display.nativedisplay.input.NativeKeyboardEditText;
+import cn.classfun.droidvm.ui.vm.display.nativedisplay.input.TouchScaleCalculator;
+
+/**
+ * Native display: shows a VM's gfxstream/virtio-gpu output by handing crosvm an Android Surface
+ * (via the per-VM ICrosvmAndroidDisplayService binder) and forwarding touch/keyboard as evdev.
+ *
+ * Input: the daemon (uid=0) owns crosvm's --input sockets (it binds them before crosvm starts and
+ * accepts the connection), so this Activity forwards evdev to the daemon rather than writing the
+ * sockets directly. The daemon hosts a broker binder ({@link INativeDisplayRootService}) that both
+ * looks up the per-VM display binder and, on the touch hot path, writes evdev straight to crosvm
+ * ({@link DirectInputSink}); the vm_input IPC command is the fallback when that path is unavailable.
+ * The binder can't ride the daemon's TCP/JSON-RPC channel, so it arrives via a broadcast the daemon
+ * sends in response to the {@code display_attach} request below.
+ */
+public final class VMNativeDisplayActivity extends AppCompatActivity {
+    private static final String TAG = "VMNativeDisplay";
+    public static final String EXTRA_VM_NAME = "vm_name";
+    public static final String EXTRA_VM_ID = "vm_id";
+    public static final String EXTRA_WIDTH = "display_width";
+    public static final String EXTRA_HEIGHT = "display_height";
+    private static final long AUTO_HIDE_DELAY_MS = 3000;
+
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    // Converts committed IME text into key events (handles Shift for upper-case/symbols).
+    private final KeyCharacterMap keyCharacterMap =
+        KeyCharacterMap.load(KeyCharacterMap.VIRTUAL_KEYBOARD);
+
+    private MaterialToolbar toolbar;
+    private LinearLayout statusBar;
+    private View statusIndicator;
+    private TextView tvStatus;
+    private LinearLayout overlayConnecting;
+    private TextView tvConnectingMessage;
+    private FrameLayout displayContainer;
+    private SurfaceView surfaceView;
+    private NativeKeyboardEditText keyboardInput;
+    private FloatingActionButton fabMenu;
+    private MaterialButton btnFullscreen;
+    private DisplayExtraKeysPanel extraKeysPanel;
+
+    private String vmName = "";
+    private String vmId = "";
+    private String vmKey = "";
+    private int guestWidth = 1280;
+    private int guestHeight = 720;
+
+    private INativeDisplayRootService rootService;
+    private DisplayProvider displayProvider;
+    private InputForwarder inputForwarder;
+    private DirectInputSink directSink;
+    private NativeExtraKeysPanel nativeExtraKeys;
+    private boolean isFullscreen = false;
+    private boolean connected = false;
+
+    // Per-attach random token: we only accept the binder broadcast carrying the nonce we requested,
+    // so another app spoofing the (exported) action can't slip us a fake broker binder.
+    private final String attachNonce = UUID.randomUUID().toString();
+    private boolean binderReceiverRegistered = false;
+    private boolean rootConnected = false;
+
+    // The daemon broadcasts its broker binder here in response to our display_attach request.
+    private final BroadcastReceiver binderReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            var bundle = intent.getBundleExtra(NativeDisplay.EXTRA_BUNDLE);
+            if (bundle == null || !attachNonce.equals(bundle.getString(NativeDisplay.EXTRA_NONCE)))
+                return;
+            var binder = bundle.getBinder(NativeDisplay.EXTRA_BINDER);
+            if (binder != null) onBinderReceived(binder);
+        }
+    };
+
+    // Daemon died (e.g. restart): drop the broker binder so writes fall back to the vm_input IPC.
+    private final IBinder.DeathRecipient deathRecipient = () -> mainHandler.post(() -> {
+        Log.w(TAG, "daemon broker binder died");
+        rootService = null;
+    });
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        setContentView(R.layout.activity_vm_native_display);
+
+        var intent = getIntent();
+        vmName = orEmpty(intent.getStringExtra(EXTRA_VM_NAME));
+        vmId = orEmpty(intent.getStringExtra(EXTRA_VM_ID));
+        guestWidth = (int) intent.getLongExtra(EXTRA_WIDTH, 1280);
+        guestHeight = (int) intent.getLongExtra(EXTRA_HEIGHT, 720);
+        vmKey = NativeDisplay.serviceNameFromId(vmId);
+
+        bindViews();
+        toolbar.setTitle(vmName.isEmpty() ? getString(R.string.native_display_title) : vmName);
+        toolbar.setNavigationOnClickListener(v -> finish());
+        setupViews();
+        setStatus(getString(R.string.native_display_connecting), R.color.vnc_status_connecting);
+        showOverlay(getString(R.string.native_display_waiting));
+
+        if (vmId.isEmpty()) {
+            setStatus(getString(R.string.native_display_failed), R.color.vnc_status_error);
+            showOverlay(getString(R.string.native_display_failed));
+            return;
+        }
+        // Ask the daemon (uid=0) for its broker binder. It can't ride the JSON-RPC channel, so the
+        // daemon broadcasts it back to binderReceiver (matched by attachNonce).
+        registerReceiver(binderReceiver,
+            new IntentFilter(NativeDisplay.BINDER_BROADCAST_ACTION), Context.RECEIVER_EXPORTED);
+        binderReceiverRegistered = true;
+        requestDisplayBinder(10);
+    }
+
+    // Sends display_attach; the daemon answers with a broadcast. Retries while the daemon connection
+    // is still coming up, since the Activity can open just before DaemonConnection authenticates.
+    private void requestDisplayBinder(int attemptsLeft) {
+        if (rootConnected || isFinishing()) return;
+        DaemonConnection.getInstance().buildRequest("display_attach")
+            .put("nonce", attachNonce)
+            .onError(e -> retryDisplayBinder(attemptsLeft))
+            .onUnsuccessful(r -> retryDisplayBinder(attemptsLeft))
+            .invoke();
+    }
+
+    private void retryDisplayBinder(int attemptsLeft) {
+        if (attemptsLeft <= 0) {
+            Log.w(TAG, "display_attach exhausted retries; daemon unavailable");
+            return;
+        }
+        mainHandler.postDelayed(() -> requestDisplayBinder(attemptsLeft - 1), 500);
+    }
+
+    private void onBinderReceived(@NonNull IBinder binder) {
+        if (rootConnected) return; // ignore duplicate broadcasts
+        rootConnected = true;
+        rootService = INativeDisplayRootService.Stub.asInterface(binder);
+        try {
+            binder.linkToDeath(deathRecipient, 0);
+        } catch (RemoteException e) {
+            Log.w(TAG, "linkToDeath failed", e);
+        }
+        onRootConnected();
+    }
+
+    private void onRootConnected() {
+        if (rootService == null) return;
+        // Try a direct unix-socket sink to the daemon (one write per evdev frame, no IPC
+        // round-trip); on any failure it falls back to the vm_input JSON-RPC path below.
+        directSink = new DirectInputSink(vmId, rootService, this::sendInputToDaemon);
+        inputForwarder = new InputForwarder(directSink);
+        if (nativeExtraKeys != null) nativeExtraKeys.setForwarder(inputForwarder);
+
+        // Start the VM now that listeners are up (no-op if already running).
+        DaemonConnection.getInstance().buildRequest("vm_start")
+            .put("vm_id", vmId)
+            .onResponse(r -> {})
+            .onUnsuccessful(r -> {})
+            .onError(e -> Log.w(TAG, "vm_start request failed", e))
+            .invoke();
+
+        // Display binder is looked up via the root service (servicemanager) on a bg thread.
+        displayProvider = new DisplayProvider(
+            surfaceView, guestWidth, guestHeight,
+            () -> {
+                var svc = rootService;
+                if (svc == null) return null;
+                try {
+                    return svc.waitForDisplayBinder(vmKey);
+                } catch (Exception e) {
+                    return null;
+                }
+            },
+            isConnected -> mainHandler.post(() -> onDisplayConnected(isConnected)),
+            config -> mainHandler.post(() -> {
+                guestWidth = config.width;
+                guestHeight = config.height;
+                updateAspectRatio(displayContainer.getWidth(), displayContainer.getHeight());
+            })
+        );
+    }
+
+    private void onDisplayConnected(boolean isConnected) {
+        connected = isConnected;
+        if (isConnected) {
+            setStatus(fmt(getString(R.string.native_display_connected), guestWidth, guestHeight),
+                R.color.vnc_status_connected);
+            hideOverlay();
+            updateAspectRatio(displayContainer.getWidth(), displayContainer.getHeight());
+        } else {
+            setStatus(getString(R.string.native_display_connecting), R.color.vnc_status_connecting);
+            showOverlay(getString(R.string.native_display_waiting));
+        }
+    }
+
+    private void bindViews() {
+        toolbar = findViewById(R.id.toolbar);
+        statusBar = findViewById(R.id.status_bar);
+        statusIndicator = findViewById(R.id.status_indicator);
+        tvStatus = findViewById(R.id.tv_status);
+        overlayConnecting = findViewById(R.id.overlay_connecting);
+        tvConnectingMessage = findViewById(R.id.tv_connecting_message);
+        displayContainer = findViewById(R.id.display_container);
+        surfaceView = findViewById(R.id.surface_view);
+        keyboardInput = findViewById(R.id.keyboard_input);
+        fabMenu = findViewById(R.id.fab_menu);
+        btnFullscreen = findViewById(R.id.btn_fullscreen);
+        extraKeysPanel = findViewById(R.id.extra_keys_panel);
+        nativeExtraKeys = new NativeExtraKeysPanel(extraKeysPanel);
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private void setupViews() {
+        btnFullscreen.setOnClickListener(v -> toggleFullscreen());
+        displayContainer.addOnLayoutChangeListener((
+            v, l, t, r, b, ol, ot, or2, ob
+        ) -> {
+            int cw = r - l, ch = b - t;
+            if (cw > 0 && ch > 0) v.post(() -> updateAspectRatio(cw, ch));
+        });
+        surfaceView.setOnTouchListener(this::onSurfaceTouch);
+        keyboardInput.setTextInputListener(new NativeKeyboardEditText.TextInputListener() {
+            @Override
+            public void onCommitText(@NonNull CharSequence text) {
+                forwardText(text);
+            }
+
+            @Override
+            public void onDeleteSurrounding(int beforeLength, int afterLength) {
+                for (int i = 0; i < beforeLength; i++) tapKey(KeyEvent.KEYCODE_DEL);
+                for (int i = 0; i < afterLength; i++) tapKey(KeyEvent.KEYCODE_FORWARD_DEL);
+            }
+        });
+        var listener = new DragTouchListener(this, this::showFabMenu);
+        fabMenu.setOnTouchListener(listener);
+    }
+
+    // Soft keyboards that commit text (instead of sending key events) land here; translate each
+    // character to its key event sequence and forward as evdev.
+    private void forwardText(@NonNull CharSequence text) {
+        if (inputForwarder == null || !connected) return;
+        KeyEvent[] events = keyCharacterMap.getEvents(text.toString().toCharArray());
+        if (events == null) return;
+        // Wrap with the extra-keys panel modifiers so e.g. Ctrl+(typed key) reaches the guest.
+        nativeExtraKeys.applyModifiers(true);
+        for (KeyEvent e : events) {
+            if (e.getAction() == KeyEvent.ACTION_DOWN) {
+                inputForwarder.sendKeyEvent(e.getKeyCode(), true);
+            } else if (e.getAction() == KeyEvent.ACTION_UP) {
+                inputForwarder.sendKeyEvent(e.getKeyCode(), false);
+            }
+        }
+        nativeExtraKeys.applyModifiers(false);
+    }
+
+    private void tapKey(int keyCode) {
+        if (inputForwarder == null || !connected) return;
+        nativeExtraKeys.applyModifiers(true);
+        inputForwarder.sendKeyEvent(keyCode, true);
+        inputForwarder.sendKeyEvent(keyCode, false);
+        nativeExtraKeys.applyModifiers(false);
+    }
+
+    private boolean onSurfaceTouch(View v, MotionEvent event) {
+        if (inputForwarder == null || v.getWidth() <= 0 || v.getHeight() <= 0) return false;
+        // The SurfaceView is sized to the guest aspect ratio, so offsets are zero and scale is
+        // simply guest/view per axis.
+        var tf = TouchScaleCalculator.compute(guestWidth, guestHeight, v.getWidth(), v.getHeight());
+        inputForwarder.sendTouchEvent(event, tf.scaleX, tf.scaleY);
+        return true;
+    }
+
+    // Sink for InputForwarder: ships encoded evdev to the daemon, which owns the crosvm input
+    // sockets and writes them to the guest. Called on the (single) InputForwarder worker thread, so
+    // the synchronous request keeps events ordered and back-pressured.
+    private boolean sendInputToDaemon(int channel, @NonNull byte[] data) {
+        try {
+            var req = new JSONObject();
+            req.put("command", "vm_input");
+            req.put("vm_id", vmId);
+            req.put("channel", channel);
+            req.put("data", Base64.encodeToString(data, Base64.NO_WRAP));
+            var resp = DaemonConnection.getInstance().request(req);
+            return resp.optBoolean("delivered", false);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean dispatchKeyEvent(@NonNull KeyEvent event) {
+        int keyCode = event.getKeyCode();
+        if (keyCode == KeyEvent.KEYCODE_VOLUME_UP || keyCode == KeyEvent.KEYCODE_VOLUME_DOWN)
+            return super.dispatchKeyEvent(event);
+        if (inputForwarder != null && connected) {
+            // Don't wrap a hardware modifier key in the panel's sticky modifiers; only real keys.
+            boolean modifier = isModifierKey(keyCode);
+            boolean handled;
+            if (event.getAction() == KeyEvent.ACTION_DOWN) {
+                if (!modifier && nativeExtraKeys.hasNonStickyModifiers())
+                    nativeExtraKeys.applyModifiers(true);
+                handled = inputForwarder.sendKeyEvent(keyCode, true);
+            } else if (event.getAction() == KeyEvent.ACTION_UP) {
+                handled = inputForwarder.sendKeyEvent(keyCode, false);
+                if (!modifier && nativeExtraKeys.hasNonStickyModifiers())
+                    nativeExtraKeys.applyModifiers(false);
+            } else {
+                handled = false;
+            }
+            if (handled) return true;
+        }
+        return super.dispatchKeyEvent(event);
+    }
+
+    private static boolean isModifierKey(int keyCode) {
+        switch (keyCode) {
+            case KeyEvent.KEYCODE_SHIFT_LEFT:
+            case KeyEvent.KEYCODE_SHIFT_RIGHT:
+            case KeyEvent.KEYCODE_CTRL_LEFT:
+            case KeyEvent.KEYCODE_CTRL_RIGHT:
+            case KeyEvent.KEYCODE_ALT_LEFT:
+            case KeyEvent.KEYCODE_ALT_RIGHT:
+            case KeyEvent.KEYCODE_META_LEFT:
+            case KeyEvent.KEYCODE_META_RIGHT:
+            case KeyEvent.KEYCODE_CAPS_LOCK:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private void updateAspectRatio(int containerW, int containerH) {
+        if (containerW <= 0 || containerH <= 0 || guestWidth <= 0 || guestHeight <= 0) return;
+        float vmAspect = (float) guestWidth / guestHeight;
+        float containerAspect = (float) containerW / containerH;
+        int viewW, viewH;
+        if (vmAspect > containerAspect) {
+            viewW = containerW;
+            viewH = Math.round(containerW / vmAspect);
+        } else {
+            viewH = containerH;
+            viewW = Math.round(containerH * vmAspect);
+        }
+        surfaceView.setLayoutParams(new FrameLayout.LayoutParams(viewW, viewH, CENTER));
+    }
+
+    private void setStatus(String text, int colorRes) {
+        tvStatus.setText(text);
+        var indicator = new GradientDrawable();
+        indicator.setShape(GradientDrawable.OVAL);
+        indicator.setColor(getColor(colorRes));
+        statusIndicator.setBackground(indicator);
+    }
+
+    private void showOverlay(String message) {
+        overlayConnecting.setVisibility(VISIBLE);
+        tvConnectingMessage.setText(message);
+    }
+
+    private void hideOverlay() {
+        overlayConnecting.setVisibility(GONE);
+    }
+
+    private void toggleSoftKeyboard() {
+        var imm = getSystemService(InputMethodManager.class);
+        if (imm != null) tryShowKeyboard(imm, 10);
+    }
+
+    // Drive a real (invisible) EditText: a SurfaceView is an unreliable IME target on some ROMs.
+    // The popup menu relinquishes window focus right before this runs, so the editor isn't yet
+    // "served" by the IMM and showSoftInput() is silently ignored (no ResultReceiver callback
+    // either). Retry on a short delay until the input connection is established; force as a last
+    // resort.
+    private void tryShowKeyboard(@NonNull InputMethodManager imm, int attemptsLeft) {
+        keyboardInput.requestFocus();
+        if (imm.showSoftInput(keyboardInput, InputMethodManager.SHOW_IMPLICIT)) return;
+        if (attemptsLeft > 0) {
+            mainHandler.postDelayed(() -> tryShowKeyboard(imm, attemptsLeft - 1), 60);
+        } else {
+            imm.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0);
+        }
+    }
+
+    private void toggleFullscreen() {
+        isFullscreen = !isFullscreen;
+        var controller = getWindow().getInsetsController();
+        if (controller == null) return;
+        if (isFullscreen) {
+            toolbar.setVisibility(GONE);
+            statusBar.setVisibility(GONE);
+            extraKeysPanel.setVisibility(GONE);
+            controller.hide(WindowInsets.Type.systemBars());
+            controller.setSystemBarsBehavior(BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+        } else {
+            toolbar.setVisibility(VISIBLE);
+            statusBar.setVisibility(VISIBLE);
+            extraKeysPanel.animateIn();
+            controller.show(WindowInsets.Type.systemBars());
+        }
+    }
+
+    private void showFabMenu() {
+        var popup = new MaterialMenu(this, fabMenu);
+        popup.inflate(R.menu.menu_native_display_menu);
+        popup.setOnMenuItemClickListener(this::onMenuItemClicked);
+        popup.show();
+    }
+
+    private boolean onMenuItemClicked(@NonNull MenuItem item) {
+        int id = item.getItemId();
+        if (id == R.id.menu_keyboard) {
+            toggleSoftKeyboard();
+            return true;
+        } else if (id == R.id.menu_extra_keys) {
+            extraKeysPanel.setVisibleAnimated(extraKeysPanel.getVisibility() != VISIBLE);
+            return true;
+        } else if (id == R.id.menu_fullscreen) {
+            toggleFullscreen();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        extraKeysPanel.stopKeyRepeat();
+        if (displayProvider != null) {
+            displayProvider.shutdown();
+            displayProvider = null;
+        }
+        if (inputForwarder != null) {
+            inputForwarder.close();
+            inputForwarder = null;
+        }
+        if (directSink != null) {
+            directSink.close();
+            directSink = null;
+        }
+        if (binderReceiverRegistered) {
+            try {
+                unregisterReceiver(binderReceiver);
+            } catch (Exception ignored) {
+            }
+            binderReceiverRegistered = false;
+        }
+        if (rootService != null) {
+            try {
+                rootService.asBinder().unlinkToDeath(deathRecipient, 0);
+            } catch (Exception ignored) {
+            }
+        }
+        rootService = null;
+    }
+
+    @NonNull
+    private static String orEmpty(@Nullable String s) {
+        return s == null ? "" : s;
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/display/nativedisplay/input/DirectInputSink.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/display/nativedisplay/input/DirectInputSink.java
@@ -1,0 +1,71 @@
+package cn.classfun.droidvm.ui.vm.display.nativedisplay.input;
+
+import static cn.classfun.droidvm.lib.store.vm.NativeDisplay.CHANNEL_COUNT;
+import static cn.classfun.droidvm.lib.utils.StringUtils.fmt;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import cn.classfun.droidvm.display.INativeDisplayRootService;
+
+/**
+ * {@link InputForwarder.InputSink} that hands pre-encoded evdev straight to the daemon via its
+ * binder ({@link INativeDisplayRootService#writeInput}), which writes it to the crosvm input socket
+ * it owns - bypassing the slow vm_input JSON-RPC round-trip. An untrusted_app can neither
+ * {@code connectto} that su-domain socket nor receive its fd over binder, but it can hand the bytes
+ * across binder. Falls back to {@code fallback} on any failure so the feature degrades to the
+ * original IPC path instead of dropping input.
+ */
+public final class DirectInputSink implements InputForwarder.InputSink {
+    private static final String TAG = "DirectInputSink";
+
+    private final String vmId;
+    private final INativeDisplayRootService rootService;
+    private final InputForwarder.InputSink fallback;
+    private volatile boolean closed = false;
+    // Whether the most recent write() went out the daemon-binder path (vs. the IPC fallback). For
+    // latency diagnostics only; the worker thread is single-threaded so a plain volatile is enough.
+    private volatile boolean lastWriteDirect = false;
+
+    /**
+     * @param vmId        the VM id, used by the daemon to find the running VM's input channel.
+     * @param rootService daemon broker binder that writes the bytes; null disables the direct path.
+     * @param fallback    sink used when the direct path is unavailable or errors.
+     */
+    public DirectInputSink(@NonNull String vmId, @Nullable INativeDisplayRootService rootService,
+                           @Nullable InputForwarder.InputSink fallback) {
+        this.vmId = vmId;
+        this.rootService = rootService;
+        this.fallback = fallback;
+    }
+
+    @Override
+    public boolean write(int channel, @NonNull byte[] data) {
+        if (closed || channel < 0 || channel >= CHANNEL_COUNT) return false;
+        if (rootService != null) {
+            try {
+                if (rootService.writeInput(vmId, channel, data)) {
+                    lastWriteDirect = true;
+                    return true;
+                }
+            } catch (Exception e) {
+                Log.w(TAG, fmt("channel %d root forward failed: %s - falling back",
+                    channel, e.getMessage()));
+            }
+        }
+        lastWriteDirect = false;
+        return fallback != null && fallback.write(channel, data);
+    }
+
+    /** True iff the most recent {@link #write} went out the daemon-binder path. Diagnostics only. */
+    public boolean wasLastWriteDirect() {
+        return lastWriteDirect;
+    }
+
+    /** Stops using the direct path; subsequent writes go through the fallback. */
+    public void close() {
+        closed = true;
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/display/nativedisplay/input/EvdevEncoder.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/display/nativedisplay/input/EvdevEncoder.java
@@ -1,0 +1,181 @@
+package cn.classfun.droidvm.ui.vm.display.nativedisplay.input;
+
+import android.view.MotionEvent;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Encodes input into the wire format crosvm's virtio-input devices read from a socket: a stream of
+ * fixed 8-byte little-endian records {@code (type: u16, code: u16, value: i32)}. crosvm connects to
+ * the socket given via {@code --input multi-touch[path=...]} / {@code keyboard[...]} and consumes
+ * these records directly. MVP scope: multi-touch + keyboard.
+ *
+ * Touch encoding is stateful (one instance per session): it keeps a pointer-id -> MT slot mapping
+ * because evdev slots must be small reused indices, while Android pointer ids can grow/be sparse;
+ * and a contact count so BTN_TOUCH toggles only on the first finger down and the last finger up.
+ * All touch methods run on the single InputForwarder worker thread, so the state needs no locking.
+ */
+public final class EvdevEncoder {
+    // from include/uapi/linux/input-event-codes.h
+    private static final short EV_SYN = 0x00;
+    private static final short EV_KEY = 0x01;
+    private static final short EV_ABS = 0x03;
+
+    private static final short SYN_REPORT = 0x00;
+
+    private static final short ABS_X = 0x00;
+    private static final short ABS_Y = 0x01;
+    private static final short ABS_MT_SLOT = 0x2f;
+    private static final short ABS_MT_POSITION_X = 0x35;
+    private static final short ABS_MT_POSITION_Y = 0x36;
+    private static final short ABS_MT_TRACKING_ID = 0x39;
+
+    private static final short BTN_TOUCH = 0x14a;
+
+    /** Live Android pointer id -> evdev MT slot. Touched only on the worker thread. */
+    private final Map<Integer, Integer> pointerSlots = new HashMap<>();
+
+    public EvdevEncoder() {
+    }
+
+    private static final class Event {
+        final short type;
+        final short code;
+        final int value;
+
+        Event(short type, short code, int value) {
+            this.type = type;
+            this.code = code;
+            this.value = value;
+        }
+    }
+
+    /** Serializes events to the contiguous 8-byte-record buffer crosvm reads (one write per batch). */
+    @NonNull
+    private static byte[] encode(@NonNull List<Event> events) {
+        var buf = ByteBuffer.allocate(8 * events.size()).order(ByteOrder.LITTLE_ENDIAN);
+        for (var e : events) {
+            buf.putShort(e.type);
+            buf.putShort(e.code);
+            buf.putInt(e.value);
+        }
+        return buf.array();
+    }
+
+    /**
+     * Encodes a key down/up plus SYN into a ready-to-send record buffer.
+     *
+     * @param scanCode Linux evdev KEY_* code (from {@link KeyCodeMapper}).
+     */
+    @NonNull
+    public static byte[] encodeKey(short scanCode, boolean down) {
+        var events = new ArrayList<Event>(2);
+        events.add(new Event(EV_KEY, scanCode, down ? 1 : 0));
+        events.add(new Event(EV_SYN, SYN_REPORT, 0));
+        return encode(events);
+    }
+
+    /**
+     * Encodes a touch {@link MotionEvent} into multi-touch evdev records, or null if there is
+     * nothing to send. The multi-touch device's ABS range must equal the guest resolution passed
+     * via {@code --input multi-touch[width=guestW,height=guestH]}.
+     *
+     * @param scaleX guestWidth / viewWidth
+     * @param scaleY guestHeight / viewHeight
+     */
+    @Nullable
+    public byte[] encodeTouch(@NonNull MotionEvent event, float scaleX, float scaleY) {
+        switch (event.getActionMasked()) {
+            case MotionEvent.ACTION_MOVE: {
+                int count = event.getPointerCount();
+                var events = new ArrayList<Event>(count * 4 + 1);
+                for (int i = 0; i < count; i++) {
+                    int id = event.getPointerId(i);
+                    Integer slot = pointerSlots.get(id);
+                    if (slot == null) continue; // no DOWN seen for this pointer; ignore
+                    int x = (int) (event.getX(i) * scaleX);
+                    int y = (int) (event.getY(i) * scaleY);
+                    events.add(new Event(EV_ABS, ABS_MT_SLOT, slot));
+                    events.add(new Event(EV_ABS, ABS_MT_POSITION_X, x));
+                    events.add(new Event(EV_ABS, ABS_MT_POSITION_Y, y));
+                    if (i == 0) { // mirror the primary pointer onto the single-touch axes
+                        events.add(new Event(EV_ABS, ABS_X, x));
+                        events.add(new Event(EV_ABS, ABS_Y, y));
+                    }
+                }
+                if (events.isEmpty()) return null;
+                events.add(new Event(EV_SYN, SYN_REPORT, 0));
+                return encode(events);
+            }
+            case MotionEvent.ACTION_DOWN:
+            case MotionEvent.ACTION_POINTER_DOWN: {
+                int idx = event.getActionIndex();
+                int id = event.getPointerId(idx);
+                int slot = allocSlot(id);
+                int x = (int) (event.getX(idx) * scaleX);
+                int y = (int) (event.getY(idx) * scaleY);
+                var events = new ArrayList<Event>(8);
+                // Only the first contact toggles BTN_TOUCH; further fingers must not re-assert it.
+                if (pointerSlots.size() == 1)
+                    events.add(new Event(EV_KEY, BTN_TOUCH, 1));
+                events.add(new Event(EV_ABS, ABS_MT_SLOT, slot));
+                events.add(new Event(EV_ABS, ABS_MT_TRACKING_ID, id));
+                events.add(new Event(EV_ABS, ABS_MT_POSITION_X, x));
+                events.add(new Event(EV_ABS, ABS_MT_POSITION_Y, y));
+                if (slot == 0) {
+                    events.add(new Event(EV_ABS, ABS_X, x));
+                    events.add(new Event(EV_ABS, ABS_Y, y));
+                }
+                events.add(new Event(EV_SYN, SYN_REPORT, 0));
+                return encode(events);
+            }
+            case MotionEvent.ACTION_UP:
+            case MotionEvent.ACTION_POINTER_UP: {
+                int id = event.getPointerId(event.getActionIndex());
+                Integer slot = pointerSlots.remove(id);
+                if (slot == null) return null;
+                var events = new ArrayList<Event>(4);
+                events.add(new Event(EV_ABS, ABS_MT_SLOT, slot));
+                events.add(new Event(EV_ABS, ABS_MT_TRACKING_ID, -1));
+                // Only release BTN_TOUCH once the last finger is up; a POINTER_UP with fingers
+                // still down must keep BTN_TOUCH asserted.
+                if (pointerSlots.isEmpty())
+                    events.add(new Event(EV_KEY, BTN_TOUCH, 0));
+                events.add(new Event(EV_SYN, SYN_REPORT, 0));
+                return encode(events);
+            }
+            case MotionEvent.ACTION_CANCEL: {
+                if (pointerSlots.isEmpty()) return null;
+                var events = new ArrayList<Event>(pointerSlots.size() * 2 + 2);
+                for (int slot : pointerSlots.values()) {
+                    events.add(new Event(EV_ABS, ABS_MT_SLOT, slot));
+                    events.add(new Event(EV_ABS, ABS_MT_TRACKING_ID, -1));
+                }
+                pointerSlots.clear();
+                events.add(new Event(EV_KEY, BTN_TOUCH, 0));
+                events.add(new Event(EV_SYN, SYN_REPORT, 0));
+                return encode(events);
+            }
+            default:
+                return null;
+        }
+    }
+
+    /** Maps a pointer id to a stable slot, allocating the lowest free slot index if new. */
+    private int allocSlot(int pointerId) {
+        Integer existing = pointerSlots.get(pointerId);
+        if (existing != null) return existing;
+        int slot = 0;
+        while (pointerSlots.containsValue(slot)) slot++;
+        pointerSlots.put(pointerId, slot);
+        return slot;
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/display/nativedisplay/input/InputForwarder.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/display/nativedisplay/input/InputForwarder.java
@@ -1,0 +1,178 @@
+package cn.classfun.droidvm.ui.vm.display.nativedisplay.input;
+
+import static cn.classfun.droidvm.lib.store.vm.NativeDisplay.KEYBOARD;
+import static cn.classfun.droidvm.lib.store.vm.NativeDisplay.MULTITOUCH;
+import static cn.classfun.droidvm.lib.utils.StringUtils.fmt;
+
+import android.os.SystemClock;
+import android.util.Log;
+import android.view.MotionEvent;
+
+import androidx.annotation.NonNull;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Centralized input forwarding to the guest VM. Events are encoded with {@link EvdevEncoder} and
+ * shipped via {@link InputSink} to the daemon (which owns the per-device unix sockets crosvm reads
+ * from) over its IPC. Each high-level event is encoded once and sent in a single sink call. Work is
+ * serialized on one background thread; MotionEvents are copied first because the framework recycles
+ * the originals.
+ *
+ * ACTION_MOVE is coalesced: the synchronous per-event IPC round-trip is far slower than the touch
+ * sample rate, so unbounded moves would pile up in the worker queue and the on-screen pointer would
+ * fall seconds behind the finger. Only the newest pending move is kept; discrete DOWN/UP/POINTER_*
+ * events are never dropped and stay ordered. MVP scope: touch + keyboard.
+ */
+public final class InputForwarder {
+    private static final String TAG = "InputForwarder";
+
+    /** Writes pre-encoded evdev bytes for a channel in the root process; false if not delivered. */
+    public interface InputSink {
+        boolean write(int channel, @NonNull byte[] data);
+    }
+
+    private final InputSink sink;
+    // Stateful touch encoder (pointer-id -> slot, contact count); single-threaded on the worker.
+    private final EvdevEncoder encoder = new EvdevEncoder();
+    private final ExecutorService worker = Executors.newSingleThreadExecutor(r -> {
+        var t = new Thread(r, "InputForwarder");
+        t.setDaemon(true);
+        return t;
+    });
+
+    // Newest pending ACTION_MOVE, coalesced so a fast finger can't outrun the synchronous IPC.
+    private final AtomicReference<TouchFrame> pendingMove = new AtomicReference<>();
+
+    private static final class TouchFrame {
+        final MotionEvent event;
+        final float scaleX;
+        final float scaleY;
+
+        TouchFrame(@NonNull MotionEvent event, float scaleX, float scaleY) {
+            this.event = event;
+            this.scaleX = scaleX;
+            this.scaleY = scaleY;
+        }
+    }
+
+    public InputForwarder(@NonNull InputSink sink) {
+        this.sink = sink;
+    }
+
+    private void submit(@NonNull String name, @NonNull Runnable block) {
+        try {
+            worker.execute(() -> {
+                try {
+                    block.run();
+                } catch (Exception e) {
+                    Log.e(TAG, name + " failed", e);
+                }
+            });
+        } catch (Exception e) {
+            Log.d(TAG, name + " dropped: " + e.getMessage());
+        }
+    }
+
+    /**
+     * @param scaleX guestWidth / viewWidth
+     * @param scaleY guestHeight / viewHeight
+     */
+    public void sendTouchEvent(@NonNull MotionEvent event, float scaleX, float scaleY) {
+        var copy = MotionEvent.obtainNoHistory(event);
+        if (event.getActionMasked() == MotionEvent.ACTION_MOVE) {
+            // Keep only the latest move; schedule a drain only when the slot was empty so the
+            // worker queue never holds more than one pending move regardless of touch rate.
+            var prev = pendingMove.getAndSet(new TouchFrame(copy, scaleX, scaleY));
+            if (prev != null) {
+                prev.event.recycle();
+            } else {
+                submit("touchMove", this::drainMove);
+            }
+        } else {
+            // DOWN/UP/POINTER_* are discrete state changes; never drop, keep them ordered.
+            submit("touchEvent", () -> sendTouchNow(copy, scaleX, scaleY));
+        }
+    }
+
+    private void drainMove() {
+        var frame = pendingMove.getAndSet(null);
+        if (frame == null) return; // already superseded; a later drain will (or did) handle it
+        sendTouchNow(frame.event, frame.scaleX, frame.scaleY);
+    }
+
+    private void sendTouchNow(@NonNull MotionEvent event, float scaleX, float scaleY) {
+        // eventTime is on the SystemClock.uptimeMillis() timebase, so the diff below is the full
+        // finger-to-sink latency (kernel input -> framework dispatch -> our worker -> sink). Read it
+        // before recycle() since the framework reuses the MotionEvent afterwards.
+        long eventTimeMs = event.getEventTime();
+        byte[] data;
+        try {
+            data = encoder.encodeTouch(event, scaleX, scaleY);
+        } catch (Exception e) {
+            Log.e(TAG, "encode touch failed", e);
+            return;
+        } finally {
+            event.recycle();
+        }
+        if (data == null) return; // nothing to send for this event
+        long sinkStartNs = System.nanoTime();
+        boolean ok = sink.write(MULTITOUCH, data);
+        double sinkMs = (System.nanoTime() - sinkStartNs) / 1_000_000.0;
+        long e2eMs = SystemClock.uptimeMillis() - eventTimeMs;
+        // direct=false means the write fell back to the vm_input JSON-RPC IPC path (~40ms) instead
+        // of the direct unix socket (<1ms) - i.e. the UI couldn't reach the daemon's UI input socket.
+        boolean direct = sink instanceof DirectInputSink && ((DirectInputSink) sink).wasLastWriteDirect();
+        Log.d(TAG, fmt("touch latency: sink=%.2fms e2e=%dms direct=%b delivered=%b",
+            sinkMs, e2eMs, direct, ok));
+    }
+
+    /**
+     * Forwards a hardware/virtual key by Android key code.
+     *
+     * @return true if the key code is mapped, false otherwise.
+     */
+    public boolean sendKeyEvent(int keyCode, boolean pressed) {
+        int base = KeyCodeMapper.shiftSynthBase(keyCode);
+        if (base != -1) {
+            int baseScan = KeyCodeMapper.androidToEvdev(base);
+            if (baseScan == -1) return false;
+            if (pressed) {
+                sendRawKeyEvent(KeyCodeMapper.KEY_LEFTSHIFT, true);
+                sendRawKeyEvent(baseScan, true);
+            } else {
+                sendRawKeyEvent(baseScan, false);
+                sendRawKeyEvent(KeyCodeMapper.KEY_LEFTSHIFT, false);
+            }
+            return true;
+        }
+        int scanCode = KeyCodeMapper.androidToEvdev(keyCode);
+        if (scanCode == -1) return false;
+        sendRawKeyEvent(scanCode, pressed);
+        return true;
+    }
+
+    /** Sends a raw Linux evdev KEY_* scan code. */
+    public void sendRawKeyEvent(int scanCode, boolean pressed) {
+        submit("sendRawKeyEvent", () -> {
+            byte[] data;
+            try {
+                data = EvdevEncoder.encodeKey((short) scanCode, pressed);
+            } catch (Exception e) {
+                Log.e(TAG, "encode key failed", e);
+                return;
+            }
+            boolean ok = sink.write(KEYBOARD, data);
+            Log.d(TAG, fmt("key scan=%d down=%b delivered=%b", scanCode, pressed, ok));
+        });
+    }
+
+    /** Shuts down the worker. Sockets are owned by the root process, not closed here. */
+    public void close() {
+        worker.shutdownNow();
+        var frame = pendingMove.getAndSet(null);
+        if (frame != null) frame.event.recycle();
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/display/nativedisplay/input/KeyCodeMapper.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/display/nativedisplay/input/KeyCodeMapper.java
@@ -1,0 +1,152 @@
+package cn.classfun.droidvm.ui.vm.display.nativedisplay.input;
+
+import android.view.KeyEvent;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Maps Android {@link KeyEvent} codes to Linux evdev scan codes (KEY_*).
+ */
+public final class KeyCodeMapper {
+    // Linux evdev KEY_* codes (from linux/input-event-codes.h)
+    public static final int KEY_ESC = 1;
+    public static final int KEY_1 = 2, KEY_2 = 3, KEY_3 = 4, KEY_4 = 5, KEY_5 = 6;
+    public static final int KEY_6 = 7, KEY_7 = 8, KEY_8 = 9, KEY_9 = 10, KEY_0 = 11;
+    public static final int KEY_MINUS = 12, KEY_EQUAL = 13, KEY_BACKSPACE = 14, KEY_TAB = 15;
+    public static final int KEY_Q = 16, KEY_W = 17, KEY_E = 18, KEY_R = 19, KEY_T = 20;
+    public static final int KEY_Y = 21, KEY_U = 22, KEY_I = 23, KEY_O = 24, KEY_P = 25;
+    public static final int KEY_LEFTBRACE = 26, KEY_RIGHTBRACE = 27, KEY_ENTER = 28;
+    public static final int KEY_LEFTCTRL = 29;
+    public static final int KEY_A = 30, KEY_S = 31, KEY_D = 32, KEY_F = 33, KEY_G = 34;
+    public static final int KEY_H = 35, KEY_J = 36, KEY_K = 37, KEY_L = 38;
+    public static final int KEY_SEMICOLON = 39, KEY_APOSTROPHE = 40, KEY_GRAVE = 41;
+    public static final int KEY_LEFTSHIFT = 42, KEY_BACKSLASH = 43;
+    public static final int KEY_Z = 44, KEY_X = 45, KEY_C = 46, KEY_V = 47, KEY_B = 48;
+    public static final int KEY_N = 49, KEY_M = 50;
+    public static final int KEY_COMMA = 51, KEY_DOT = 52, KEY_SLASH = 53, KEY_RIGHTSHIFT = 54;
+    public static final int KEY_KPASTERISK = 55, KEY_LEFTALT = 56, KEY_SPACE = 57, KEY_CAPSLOCK = 58;
+    public static final int KEY_F1 = 59, KEY_F2 = 60, KEY_F3 = 61, KEY_F4 = 62, KEY_F5 = 63;
+    public static final int KEY_F6 = 64, KEY_F7 = 65, KEY_F8 = 66, KEY_F9 = 67, KEY_F10 = 68;
+    public static final int KEY_NUMLOCK = 69, KEY_SCROLLLOCK = 70;
+    public static final int KEY_KP7 = 71, KEY_KP8 = 72, KEY_KP9 = 73, KEY_KPMINUS = 74;
+    public static final int KEY_KP4 = 75, KEY_KP5 = 76, KEY_KP6 = 77, KEY_KPPLUS = 78;
+    public static final int KEY_KP1 = 79, KEY_KP2 = 80, KEY_KP3 = 81, KEY_KP0 = 82, KEY_KPDOT = 83;
+    public static final int KEY_F11 = 87, KEY_F12 = 88, KEY_KPENTER = 96, KEY_RIGHTCTRL = 97;
+    public static final int KEY_KPSLASH = 98, KEY_SYSRQ = 99, KEY_RIGHTALT = 100;
+    public static final int KEY_HOME = 102, KEY_UP = 103, KEY_PAGEUP = 104, KEY_LEFT = 105;
+    public static final int KEY_RIGHT = 106, KEY_END = 107, KEY_DOWN = 108, KEY_PAGEDOWN = 109;
+    public static final int KEY_INSERT = 110, KEY_DELETE = 111, KEY_PAUSE = 119;
+    public static final int KEY_KPEQUAL = 117, KEY_LEFTMETA = 125, KEY_RIGHTMETA = 126;
+
+    private static final Map<Integer, Integer> KEYCODE_MAP = new HashMap<>();
+
+    static {
+        // Letters
+        put(KeyEvent.KEYCODE_A, KEY_A); put(KeyEvent.KEYCODE_B, KEY_B);
+        put(KeyEvent.KEYCODE_C, KEY_C); put(KeyEvent.KEYCODE_D, KEY_D);
+        put(KeyEvent.KEYCODE_E, KEY_E); put(KeyEvent.KEYCODE_F, KEY_F);
+        put(KeyEvent.KEYCODE_G, KEY_G); put(KeyEvent.KEYCODE_H, KEY_H);
+        put(KeyEvent.KEYCODE_I, KEY_I); put(KeyEvent.KEYCODE_J, KEY_J);
+        put(KeyEvent.KEYCODE_K, KEY_K); put(KeyEvent.KEYCODE_L, KEY_L);
+        put(KeyEvent.KEYCODE_M, KEY_M); put(KeyEvent.KEYCODE_N, KEY_N);
+        put(KeyEvent.KEYCODE_O, KEY_O); put(KeyEvent.KEYCODE_P, KEY_P);
+        put(KeyEvent.KEYCODE_Q, KEY_Q); put(KeyEvent.KEYCODE_R, KEY_R);
+        put(KeyEvent.KEYCODE_S, KEY_S); put(KeyEvent.KEYCODE_T, KEY_T);
+        put(KeyEvent.KEYCODE_U, KEY_U); put(KeyEvent.KEYCODE_V, KEY_V);
+        put(KeyEvent.KEYCODE_W, KEY_W); put(KeyEvent.KEYCODE_X, KEY_X);
+        put(KeyEvent.KEYCODE_Y, KEY_Y); put(KeyEvent.KEYCODE_Z, KEY_Z);
+        // Numbers
+        put(KeyEvent.KEYCODE_0, KEY_0); put(KeyEvent.KEYCODE_1, KEY_1);
+        put(KeyEvent.KEYCODE_2, KEY_2); put(KeyEvent.KEYCODE_3, KEY_3);
+        put(KeyEvent.KEYCODE_4, KEY_4); put(KeyEvent.KEYCODE_5, KEY_5);
+        put(KeyEvent.KEYCODE_6, KEY_6); put(KeyEvent.KEYCODE_7, KEY_7);
+        put(KeyEvent.KEYCODE_8, KEY_8); put(KeyEvent.KEYCODE_9, KEY_9);
+        // Function keys
+        put(KeyEvent.KEYCODE_F1, KEY_F1); put(KeyEvent.KEYCODE_F2, KEY_F2);
+        put(KeyEvent.KEYCODE_F3, KEY_F3); put(KeyEvent.KEYCODE_F4, KEY_F4);
+        put(KeyEvent.KEYCODE_F5, KEY_F5); put(KeyEvent.KEYCODE_F6, KEY_F6);
+        put(KeyEvent.KEYCODE_F7, KEY_F7); put(KeyEvent.KEYCODE_F8, KEY_F8);
+        put(KeyEvent.KEYCODE_F9, KEY_F9); put(KeyEvent.KEYCODE_F10, KEY_F10);
+        put(KeyEvent.KEYCODE_F11, KEY_F11); put(KeyEvent.KEYCODE_F12, KEY_F12);
+        // Modifiers
+        put(KeyEvent.KEYCODE_SHIFT_LEFT, KEY_LEFTSHIFT);
+        put(KeyEvent.KEYCODE_SHIFT_RIGHT, KEY_RIGHTSHIFT);
+        put(KeyEvent.KEYCODE_CTRL_LEFT, KEY_LEFTCTRL);
+        put(KeyEvent.KEYCODE_CTRL_RIGHT, KEY_RIGHTCTRL);
+        put(KeyEvent.KEYCODE_ALT_LEFT, KEY_LEFTALT);
+        put(KeyEvent.KEYCODE_ALT_RIGHT, KEY_RIGHTALT);
+        put(KeyEvent.KEYCODE_META_LEFT, KEY_LEFTMETA);
+        put(KeyEvent.KEYCODE_META_RIGHT, KEY_RIGHTMETA);
+        // Special keys
+        put(KeyEvent.KEYCODE_ENTER, KEY_ENTER); put(KeyEvent.KEYCODE_TAB, KEY_TAB);
+        put(KeyEvent.KEYCODE_SPACE, KEY_SPACE); put(KeyEvent.KEYCODE_DEL, KEY_BACKSPACE);
+        put(KeyEvent.KEYCODE_ESCAPE, KEY_ESC); put(KeyEvent.KEYCODE_FORWARD_DEL, KEY_DELETE);
+        // Navigation
+        put(KeyEvent.KEYCODE_DPAD_UP, KEY_UP); put(KeyEvent.KEYCODE_DPAD_DOWN, KEY_DOWN);
+        put(KeyEvent.KEYCODE_DPAD_LEFT, KEY_LEFT); put(KeyEvent.KEYCODE_DPAD_RIGHT, KEY_RIGHT);
+        put(KeyEvent.KEYCODE_PAGE_UP, KEY_PAGEUP); put(KeyEvent.KEYCODE_PAGE_DOWN, KEY_PAGEDOWN);
+        put(KeyEvent.KEYCODE_MOVE_HOME, KEY_HOME); put(KeyEvent.KEYCODE_MOVE_END, KEY_END);
+        put(KeyEvent.KEYCODE_INSERT, KEY_INSERT);
+        // Punctuation
+        put(KeyEvent.KEYCODE_MINUS, KEY_MINUS); put(KeyEvent.KEYCODE_EQUALS, KEY_EQUAL);
+        put(KeyEvent.KEYCODE_LEFT_BRACKET, KEY_LEFTBRACE);
+        put(KeyEvent.KEYCODE_RIGHT_BRACKET, KEY_RIGHTBRACE);
+        put(KeyEvent.KEYCODE_BACKSLASH, KEY_BACKSLASH);
+        put(KeyEvent.KEYCODE_SEMICOLON, KEY_SEMICOLON);
+        put(KeyEvent.KEYCODE_APOSTROPHE, KEY_APOSTROPHE);
+        put(KeyEvent.KEYCODE_GRAVE, KEY_GRAVE); put(KeyEvent.KEYCODE_COMMA, KEY_COMMA);
+        put(KeyEvent.KEYCODE_PERIOD, KEY_DOT); put(KeyEvent.KEYCODE_SLASH, KEY_SLASH);
+        // Numpad
+        put(KeyEvent.KEYCODE_NUMPAD_0, KEY_KP0); put(KeyEvent.KEYCODE_NUMPAD_1, KEY_KP1);
+        put(KeyEvent.KEYCODE_NUMPAD_2, KEY_KP2); put(KeyEvent.KEYCODE_NUMPAD_3, KEY_KP3);
+        put(KeyEvent.KEYCODE_NUMPAD_4, KEY_KP4); put(KeyEvent.KEYCODE_NUMPAD_5, KEY_KP5);
+        put(KeyEvent.KEYCODE_NUMPAD_6, KEY_KP6); put(KeyEvent.KEYCODE_NUMPAD_7, KEY_KP7);
+        put(KeyEvent.KEYCODE_NUMPAD_8, KEY_KP8); put(KeyEvent.KEYCODE_NUMPAD_9, KEY_KP9);
+        put(KeyEvent.KEYCODE_NUMPAD_DIVIDE, KEY_KPSLASH);
+        put(KeyEvent.KEYCODE_NUMPAD_MULTIPLY, KEY_KPASTERISK);
+        put(KeyEvent.KEYCODE_NUMPAD_SUBTRACT, KEY_KPMINUS);
+        put(KeyEvent.KEYCODE_NUMPAD_ADD, KEY_KPPLUS);
+        put(KeyEvent.KEYCODE_NUMPAD_DOT, KEY_KPDOT);
+        put(KeyEvent.KEYCODE_NUMPAD_ENTER, KEY_KPENTER);
+        put(KeyEvent.KEYCODE_NUMPAD_EQUALS, KEY_KPEQUAL);
+        put(KeyEvent.KEYCODE_NUM_LOCK, KEY_NUMLOCK);
+        // Other
+        put(KeyEvent.KEYCODE_CAPS_LOCK, KEY_CAPSLOCK);
+        put(KeyEvent.KEYCODE_SCROLL_LOCK, KEY_SCROLLLOCK);
+        put(KeyEvent.KEYCODE_BREAK, KEY_PAUSE);
+        put(KeyEvent.KEYCODE_SYSRQ, KEY_SYSRQ);
+    }
+
+    private KeyCodeMapper() {
+    }
+
+    private static void put(int androidKey, int evdev) {
+        KEYCODE_MAP.put(androidKey, evdev);
+    }
+
+    /** Linux evdev KEY_* for an Android key code, or -1 if unmapped. */
+    public static int androidToEvdev(int keyCode) {
+        Integer v = KEYCODE_MAP.get(keyCode);
+        return v == null ? -1 : v;
+    }
+
+    /**
+     * Some Android keys need Shift synthesized (e.g. {@code @} = Shift+2). Returns the base Android
+     * key code to hold with Shift, or -1 if no synthesis is needed.
+     */
+    public static int shiftSynthBase(int keyCode) {
+        switch (keyCode) {
+            case KeyEvent.KEYCODE_AT:
+                return KeyEvent.KEYCODE_2;     // @
+            case KeyEvent.KEYCODE_POUND:
+                return KeyEvent.KEYCODE_3;     // #
+            case KeyEvent.KEYCODE_STAR:
+                return KeyEvent.KEYCODE_8;     // *
+            case KeyEvent.KEYCODE_PLUS:
+                return KeyEvent.KEYCODE_EQUALS; // +
+            default:
+                return -1;
+        }
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/display/nativedisplay/input/NativeExtraKeysPanel.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/display/nativedisplay/input/NativeExtraKeysPanel.java
@@ -1,0 +1,57 @@
+package cn.classfun.droidvm.ui.vm.display.nativedisplay.input;
+
+import static android.view.KeyEvent.KEYCODE_CAPS_LOCK;
+import static android.view.KeyEvent.KEYCODE_MINUS;
+import static android.view.KeyEvent.KEYCODE_SLASH;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import cn.classfun.droidvm.ui.vm.display.base.BaseExtraKeysAdapter;
+import cn.classfun.droidvm.ui.vm.display.base.DisplayExtraKeysPanel;
+
+/**
+ * Adapts the shared {@link DisplayExtraKeysPanel} to the native backend, emitting evdev key events
+ * through {@link InputForwarder}. The sticky-modifier handling lives in {@link BaseExtraKeysAdapter};
+ * only the emit/ready hooks and the repeat/caps key mapping are backend-specific.
+ */
+public final class NativeExtraKeysPanel extends BaseExtraKeysAdapter {
+    @Nullable
+    private InputForwarder forwarder;
+
+    public NativeExtraKeysPanel(@NonNull DisplayExtraKeysPanel panel) {
+        super(panel);
+    }
+
+    public void setForwarder(@Nullable InputForwarder forwarder) {
+        this.forwarder = forwarder;
+    }
+
+    @Override
+    protected void emitKey(int androidKeyCode, boolean down) {
+        if (forwarder != null) forwarder.sendKeyEvent(androidKeyCode, down);
+    }
+
+    @Override
+    protected boolean isReady() {
+        return forwarder != null;
+    }
+
+    @Override
+    public void onKeyRepeat(int androidKeyCode) {
+        tapKey(androidKeyCode);
+    }
+
+    @Override
+    public void onCharRepeat(char ch) {
+        if (ch == '/') tapKey(KEYCODE_SLASH);
+        else if (ch == '-') tapKey(KEYCODE_MINUS);
+    }
+
+    @Override
+    public void onCapsToggle(boolean active) {
+        if (!isReady()) return;
+        emitKey(KEYCODE_CAPS_LOCK, true);
+        emitKey(KEYCODE_CAPS_LOCK, false);
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/display/nativedisplay/input/NativeKeyboardEditText.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/display/nativedisplay/input/NativeKeyboardEditText.java
@@ -1,0 +1,70 @@
+package cn.classfun.droidvm.ui.vm.display.nativedisplay.input;
+
+import android.content.Context;
+import android.text.InputType;
+import android.util.AttributeSet;
+import android.view.inputmethod.BaseInputConnection;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.AppCompatEditText;
+
+/**
+ * Invisible EditText whose only job is to host the IME for the native display. A SurfaceView is an
+ * unreliable soft-keyboard target on some ROMs (showSoftInput is silently ignored), so keyboard
+ * focus and input are delegated to this real editor instead.
+ *
+ * It uses {@code TYPE_NULL} so IMEs send raw key events (routed to the Activity's dispatchKeyEvent)
+ * while keyboards that commit text report it through the listener. No text accumulates in the field.
+ */
+public final class NativeKeyboardEditText extends AppCompatEditText {
+    public interface TextInputListener {
+        void onCommitText(@NonNull CharSequence text);
+
+        void onDeleteSurrounding(int beforeLength, int afterLength);
+    }
+
+    @Nullable
+    private TextInputListener textInputListener;
+
+    public NativeKeyboardEditText(@NonNull Context context) {
+        super(context);
+    }
+
+    public NativeKeyboardEditText(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public NativeKeyboardEditText(@NonNull Context context, @Nullable AttributeSet attrs,
+                                  int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    public void setTextInputListener(@Nullable TextInputListener listener) {
+        this.textInputListener = listener;
+    }
+
+    @NonNull
+    @Override
+    public InputConnection onCreateInputConnection(@NonNull EditorInfo outAttrs) {
+        outAttrs.inputType = InputType.TYPE_NULL;
+        outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_FULLSCREEN | EditorInfo.IME_FLAG_NO_EXTRACT_UI;
+        return new BaseInputConnection(this, false) {
+            @Override
+            public boolean commitText(CharSequence text, int newCursorPosition) {
+                if (text != null && textInputListener != null)
+                    textInputListener.onCommitText(text);
+                return true;
+            }
+
+            @Override
+            public boolean deleteSurroundingText(int beforeLength, int afterLength) {
+                if (textInputListener != null)
+                    textInputListener.onDeleteSurrounding(beforeLength, afterLength);
+                return true;
+            }
+        };
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/display/nativedisplay/input/TouchScaleCalculator.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/display/nativedisplay/input/TouchScaleCalculator.java
@@ -1,0 +1,31 @@
+package cn.classfun.droidvm.ui.vm.display.nativedisplay.input;
+
+/**
+ * Computes per-axis touch scale from view size to guest resolution. The touch listener is attached
+ * to the SurfaceView, which is itself sized to the guest aspect ratio (see
+ * {@code VMNativeDisplayActivity#updateAspectRatio}), so its bounds carry no letterbox/pillarbox
+ * bars: there is no offset and scale is simply guest/view per axis.
+ */
+public final class TouchScaleCalculator {
+    private TouchScaleCalculator() {
+    }
+
+    public static final class TouchTransform {
+        public final float scaleX;
+        public final float scaleY;
+
+        TouchTransform(float scaleX, float scaleY) {
+            this.scaleX = scaleX;
+            this.scaleY = scaleY;
+        }
+    }
+
+    public static TouchTransform compute(int guestWidth, int guestHeight,
+                                         int viewWidth, int viewHeight) {
+        if (viewWidth <= 0 || viewHeight <= 0 || guestWidth <= 0 || guestHeight <= 0) {
+            return new TouchTransform(1f, 1f);
+        }
+        return new TouchTransform((float) guestWidth / viewWidth,
+            (float) guestHeight / viewHeight);
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/display/vnc/input/VncExtraKeysPanel.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/display/vnc/input/VncExtraKeysPanel.java
@@ -1,26 +1,26 @@
 package cn.classfun.droidvm.ui.vm.display.vnc.input;
 
-import static android.view.KeyEvent.*;
+import static android.view.KeyEvent.KEYCODE_CAPS_LOCK;
 import static cn.classfun.droidvm.ui.vm.display.base.X11Keymap.androidKeyToXKeysym;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import cn.classfun.droidvm.ui.vm.display.base.BaseExtraKeysAdapter;
 import cn.classfun.droidvm.ui.vm.display.base.DisplayExtraKeysPanel;
-import cn.classfun.droidvm.ui.vm.display.base.KeyListener;
 import cn.classfun.droidvm.ui.vm.display.vnc.base.VncClient;
 
-public final class VncExtraKeysPanel implements KeyListener {
+/**
+ * Adapts the shared {@link DisplayExtraKeysPanel} to a VNC backend, emitting X keysyms through
+ * {@link VncClient}. The sticky-modifier handling lives in {@link BaseExtraKeysAdapter}; only the
+ * emit/ready hooks and the keysym-level send helpers are backend-specific.
+ */
+public final class VncExtraKeysPanel extends BaseExtraKeysAdapter {
     @Nullable
     private VncClient vncClient;
-    @NonNull
-    private final DisplayExtraKeysPanel panel;
-
-    private boolean ctrlSticky, altSticky, shiftSticky, winSticky;
 
     public VncExtraKeysPanel(@NonNull DisplayExtraKeysPanel panel) {
-        this.panel = panel;
-        panel.setKeyListener(this);
+        super(panel);
     }
 
     public void setVncClient(@Nullable VncClient client) {
@@ -33,34 +33,18 @@ public final class VncExtraKeysPanel implements KeyListener {
         return panel;
     }
 
-    public boolean hasNonStickyModifiers() {
-        return (panel.isCtrlDown() && !ctrlSticky)
-            || (panel.isAltDown() && !altSticky)
-            || (panel.isShiftDown() && !shiftSticky)
-            || (panel.isWinDown() && !winSticky);
+    @Override
+    protected void emitKey(int androidKeyCode, boolean down) {
+        if (vncClient != null) vncClient.sendKey(androidKeyToXKeysym(androidKeyCode), down);
     }
 
-    public void applyModifiers(boolean down) {
-        if (vncClient == null || !vncClient.isConnected()) return;
-        if (panel.isCtrlDown() && !ctrlSticky)
-            vncClient.sendKey(androidKeyToXKeysym(KEYCODE_CTRL_LEFT), down);
-        if (panel.isAltDown() && !altSticky)
-            vncClient.sendKey(androidKeyToXKeysym(KEYCODE_ALT_LEFT), down);
-        if (panel.isShiftDown() && !shiftSticky)
-            vncClient.sendKey(androidKeyToXKeysym(KEYCODE_SHIFT_LEFT), down);
-        if (panel.isWinDown() && !winSticky)
-            vncClient.sendKey(androidKeyToXKeysym(KEYCODE_META_LEFT), down);
-        if (!down) {
-            if (!ctrlSticky) panel.setCtrlDown(false);
-            if (!altSticky) panel.setAltDown(false);
-            if (!shiftSticky) panel.setShiftDown(false);
-            if (!winSticky) panel.setWinDown(false);
-            panel.updateToggleButtons();
-        }
+    @Override
+    protected boolean isReady() {
+        return vncClient != null && vncClient.isConnected();
     }
 
     public void sendKeysym(int keysym) {
-        if (vncClient == null || !vncClient.isConnected() || keysym == 0) return;
+        if (!isReady() || keysym == 0) return;
         applyModifiers(true);
         vncClient.sendKey(keysym, true);
         vncClient.sendKey(keysym, false);
@@ -85,69 +69,8 @@ public final class VncExtraKeysPanel implements KeyListener {
         sendChar(ch);
     }
 
-
     @Override
     public void onCapsToggle(boolean active) {
         sendKey(KEYCODE_CAPS_LOCK);
-    }
-
-    @Override
-    public void onModifierClick(int androidKeyCode) {
-        if (getSticky(androidKeyCode)) {
-            setSticky(androidKeyCode, false);
-            setDown(androidKeyCode, false);
-            if (vncClient != null && vncClient.isConnected())
-                vncClient.sendKey(androidKeyToXKeysym(androidKeyCode), false);
-        } else {
-            setDown(androidKeyCode, !getDown(androidKeyCode));
-        }
-        panel.updateToggleButtons();
-    }
-
-    @Override
-    public void onModifierLongClick(int androidKeyCode) {
-        setDown(androidKeyCode, true);
-        setSticky(androidKeyCode, true);
-        if (vncClient != null && vncClient.isConnected())
-            vncClient.sendKey(androidKeyToXKeysym(androidKeyCode), true);
-        panel.updateToggleButtons();
-    }
-
-    private boolean getDown(int keyCode) {
-        switch (keyCode) {
-            case KEYCODE_CTRL_LEFT: return panel.isCtrlDown();
-            case KEYCODE_ALT_LEFT: return panel.isAltDown();
-            case KEYCODE_SHIFT_LEFT: return panel.isShiftDown();
-            case KEYCODE_META_LEFT: return panel.isWinDown();
-            default: return false;
-        }
-    }
-
-    private void setDown(int keyCode, boolean value) {
-        switch (keyCode) {
-            case KEYCODE_CTRL_LEFT: panel.setCtrlDown(value); break;
-            case KEYCODE_ALT_LEFT: panel.setAltDown(value); break;
-            case KEYCODE_SHIFT_LEFT: panel.setShiftDown(value); break;
-            case KEYCODE_META_LEFT: panel.setWinDown(value); break;
-        }
-    }
-
-    private boolean getSticky(int keyCode) {
-        switch (keyCode) {
-            case KEYCODE_CTRL_LEFT: return ctrlSticky;
-            case KEYCODE_ALT_LEFT: return altSticky;
-            case KEYCODE_SHIFT_LEFT: return shiftSticky;
-            case KEYCODE_META_LEFT: return winSticky;
-            default: return false;
-        }
-    }
-
-    private void setSticky(int keyCode, boolean value) {
-        switch (keyCode) {
-            case KEYCODE_CTRL_LEFT: ctrlSticky = value; break;
-            case KEYCODE_ALT_LEFT: altSticky = value; break;
-            case KEYCODE_SHIFT_LEFT: shiftSticky = value; break;
-            case KEYCODE_META_LEFT: winSticky = value; break;
-        }
     }
 }

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/edit/graphics/VMEditGraphicsTab.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/edit/graphics/VMEditGraphicsTab.java
@@ -38,6 +38,7 @@ public final class VMEditGraphicsTab extends VMEditBaseTab {
     private SwitchRowWidget swVncEnabled;
     private SwitchRowWidget swVncPasswordAuth;
     private SwitchRowWidget swDisplayEnabled;
+    private SwitchRowWidget swNativeDisplayEnabled;
     private ChooseRowWidget chooseGpuBackend;
     private ChooseRowWidget chooseGpuApi;
     private ChooseRowWidget chooseDisplayBackend;
@@ -63,6 +64,7 @@ public final class VMEditGraphicsTab extends VMEditBaseTab {
         chooseGpuApi = view.findViewById(R.id.choose_gpu_api);
         gpuOptions = view.findViewById(R.id.gpu_options);
         swDisplayEnabled = view.findViewById(R.id.sw_display_enabled);
+        swNativeDisplayEnabled = view.findViewById(R.id.sw_native_display_enabled);
         chooseDisplayBackend = view.findViewById(R.id.choose_display_backend);
         displayOptions = view.findViewById(R.id.display_options);
         etDisplayWidth = view.findViewById(R.id.et_display_width);
@@ -114,6 +116,7 @@ public final class VMEditGraphicsTab extends VMEditBaseTab {
         var item = config.item;
         swGpuEnabled.setChecked(item.optBoolean("gpu_enabled", false));
         swDisplayEnabled.setChecked(item.optBoolean("display_enabled", false));
+        swNativeDisplayEnabled.setChecked(item.optBoolean("native_display_enabled", false));
         etDisplayWidth.setText(String.valueOf(item.optLong("display_width", 1280)));
         etDisplayHeight.setText(String.valueOf(item.optLong("display_height", 720)));
         etDisplayRefreshRate.setText(String.valueOf(item.optLong("display_refresh_rate", 60)));
@@ -189,6 +192,10 @@ public final class VMEditGraphicsTab extends VMEditBaseTab {
         if (displayEnabled) {
             DisplayBackend displayBackend = chooseDisplayBackend.getSelectedItem();
             item.set("display_backend", displayBackend);
+            // Native display only applies to virtio-gpu + GPU enabled.
+            item.set("native_display_enabled", gpuEnabled
+                && displayBackend == DisplayBackend.VIRTIO_GPU
+                && swNativeDisplayEnabled.isChecked());
             item.set("display_width", parseInt(getEditText(etDisplayWidth)));
             item.set("display_height", parseInt(getEditText(etDisplayHeight)));
             item.set("display_refresh_rate", parseInt(getEditText(etDisplayRefreshRate)));
@@ -214,6 +221,7 @@ public final class VMEditGraphicsTab extends VMEditBaseTab {
             if (chooseDisplayBackend.getSelectedItem() == DisplayBackend.VIRTIO_GPU)
                 chooseDisplayBackend.setSelectedItem(SIMPLEFB);
         }
+        updateNativeDisplayVisibility();
     }
 
     private void updateDisplayVisibility() {
@@ -223,6 +231,15 @@ public final class VMEditGraphicsTab extends VMEditBaseTab {
     private void updateDisplayDpiVisibility() {
         var backend = chooseDisplayBackend.getSelectedItem();
         displayDpiOptions.setVisibility(backend != SIMPLEFB ? VISIBLE : GONE);
+        updateNativeDisplayVisibility();
+    }
+
+    private void updateNativeDisplayVisibility() {
+        // Native display rides on virtio-gpu (gfxstream) only.
+        boolean ok = swGpuEnabled.isChecked()
+            && chooseDisplayBackend.getSelectedItem() == DisplayBackend.VIRTIO_GPU;
+        swNativeDisplayEnabled.setVisibility(ok ? VISIBLE : GONE);
+        if (!ok) swNativeDisplayEnabled.setChecked(false);
     }
 
     private void updateVncVisibility() {

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/info/ConsoleButton.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/info/ConsoleButton.java
@@ -24,6 +24,7 @@ import cn.classfun.droidvm.lib.store.base.DataItem;
 import cn.classfun.droidvm.lib.store.vm.VMState;
 import cn.classfun.droidvm.lib.ui.IconItemAdapter;
 import cn.classfun.droidvm.ui.vm.console.VMConsoleActivity;
+import cn.classfun.droidvm.ui.vm.display.nativedisplay.display.VMNativeDisplayActivity;
 import cn.classfun.droidvm.ui.vm.display.vnc.base.BaseVncActivity;
 import cn.classfun.droidvm.ui.vm.display.vnc.display.VMVncDisplayActivity;
 import cn.classfun.droidvm.ui.vm.display.vnc.display.VMVncPresentationActivity;
@@ -53,6 +54,11 @@ public final class ConsoleButton {
     }
 
     void openDefaultConsole() {
+        if (parent.config != null
+            && parent.config.item.optBoolean("native_display_enabled", false)) {
+            openNativeDisplay();
+            return;
+        }
         if (parent.config != null && parent.config.item.optBoolean("vnc_enabled", false)) {
             openVncDisplay();
             return;
@@ -96,6 +102,12 @@ public final class ConsoleButton {
         var running = parent.currentState != VMState.STOPPED;
         var cfg = parent.config == null ? DataItem.newObject() : parent.config.item;
         var hasVnc = running && cfg.optBoolean("vnc_enabled", false);
+        var hasNative = running && cfg.optBoolean("native_display_enabled", false);
+        if (hasNative) {
+            names.add("native");
+            titles.add(parent.getString(R.string.vm_info_console_native_select));
+            icons.add(R.drawable.ic_monitor);
+        }
         if (hasVnc) {
             names.add("vnc");
             titles.add(parent.getString(R.string.vm_info_console_vnc_select));
@@ -108,14 +120,16 @@ public final class ConsoleButton {
             Toast.makeText(parent, R.string.vm_info_console_not_found, LENGTH_SHORT).show();
             return;
         }
-        if (names.size() == 1 && !hasVnc) {
+        if (names.size() == 1 && !hasVnc && !hasNative) {
             openConsole(names.get(0));
             return;
         }
         var adapter = IconItemAdapter.create(parent, titles, icons);
         DialogInterface.OnClickListener callback = (dialog, which) -> {
             var selected = names.get(which);
-            if (selected.equals("vnc")) {
+            if (selected.equals("native")) {
+                openNativeDisplay();
+            } else if (selected.equals("vnc")) {
                 openVncDisplay();
             } else if (selected.equals("vnc-ext")) {
                 openVncExtDisplay();
@@ -135,6 +149,17 @@ public final class ConsoleButton {
         intent.putExtra(VMConsoleActivity.EXTRA_VM_NAME, parent.config.getName());
         intent.putExtra(VMConsoleActivity.EXTRA_STREAM, stream);
         intent.putExtra(VMConsoleActivity.EXTRA_LOGS, parent.currentState == VMState.STOPPED);
+        parent.startActivity(intent);
+    }
+
+    private void openNativeDisplay() {
+        if (parent.config == null) return;
+        var item = parent.config.item;
+        var intent = new Intent(parent, VMNativeDisplayActivity.class);
+        intent.putExtra(VMNativeDisplayActivity.EXTRA_VM_ID, parent.vmId.toString());
+        intent.putExtra(VMNativeDisplayActivity.EXTRA_VM_NAME, parent.config.getName());
+        intent.putExtra(VMNativeDisplayActivity.EXTRA_WIDTH, item.optLong("display_width", 1280));
+        intent.putExtra(VMNativeDisplayActivity.EXTRA_HEIGHT, item.optLong("display_height", 720));
         parent.startActivity(intent);
     }
 

--- a/app/src/main/res/layout/activity_vm_native_display.xml
+++ b/app/src/main/res/layout/activity_vm_native_display.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/vnc_background"
+    android:fitsSystemWindows="true"
+    android:orientation="vertical"
+    tools:context=".ui.vm.display.nativedisplay.display.VMNativeDisplayActivity">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        app:navigationIcon="?attr/homeAsUpIndicator"
+        app:titleTextColor="@android:color/white" />
+
+    <LinearLayout
+        android:id="@+id/status_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/vnc_status_bar_background"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingHorizontal="16dp"
+        android:paddingVertical="8dp">
+
+        <View
+            android:id="@+id/status_indicator"
+            android:layout_width="10dp"
+            android:layout_height="10dp"
+            android:background="@android:color/holo_orange_dark" />
+
+        <TextView
+            android:id="@+id/tv_status"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_weight="1"
+            android:fontFamily="monospace"
+            android:text="@string/native_display_connecting"
+            android:textColor="@android:color/white"
+            android:textSize="13sp" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_fullscreen"
+            style="@style/Widget.Material3.Button.IconButton"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:contentDescription="@string/vnc_display_fullscreen"
+            app:icon="@drawable/ic_fullscreen"
+            app:iconTint="@android:color/white" />
+
+    </LinearLayout>
+
+    <FrameLayout
+        android:id="@+id/display_container"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:background="@color/vnc_background"
+        android:clickable="true">
+
+        <SurfaceView
+            android:id="@+id/surface_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="center" />
+
+        <!-- Editor that hosts the IME; SurfaceView is an unreliable keyboard target. Kept visually
+             imperceptible (1px, transparent text/background, no cursor) rather than alpha=0, because
+             some ROMs (e.g. OPlus) refuse to show the keyboard for a fully invisible editor. -->
+        <cn.classfun.droidvm.ui.vm.display.nativedisplay.input.NativeKeyboardEditText
+            android:id="@+id/keyboard_input"
+            android:layout_width="1dp"
+            android:layout_height="1dp"
+            android:layout_gravity="bottom|start"
+            android:background="@android:color/transparent"
+            android:cursorVisible="false"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
+            android:importantForAccessibility="no"
+            android:importantForAutofill="no"
+            android:inputType="text"
+            android:textColor="@android:color/transparent"
+            tools:ignore="LabelFor,TextFields" />
+
+        <LinearLayout
+            android:id="@+id/overlay_connecting"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:padding="24dp">
+
+            <ProgressBar
+                android:id="@+id/progress_connecting"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:indeterminate="true"
+                android:indeterminateTint="@android:color/white" />
+
+            <TextView
+                android:id="@+id/tv_connecting_message"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:gravity="center"
+                android:text="@string/native_display_connecting"
+                android:textColor="@android:color/white"
+                android:textSize="14sp" />
+
+        </LinearLayout>
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab_menu"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
+            android:layout_margin="16dp"
+            android:alpha="0.7"
+            android:contentDescription="@string/menu"
+            app:backgroundTint="@color/vnc_fab_background"
+            app:elevation="4dp"
+            app:fabCustomSize="32dp"
+            app:maxImageSize="16dp"
+            app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.Fab.Circle"
+            app:srcCompat="@drawable/ic_more_vert"
+            app:tint="@android:color/white"
+            tools:ignore="ClassNameCheck" />
+
+    </FrameLayout>
+
+    <cn.classfun.droidvm.ui.vm.display.base.DisplayExtraKeysPanel
+        android:id="@+id/extra_keys_panel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="bottom"
+        android:orientation="vertical" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/partial_vm_edit_graphics.xml
+++ b/app/src/main/res/layout/partial_vm_edit_graphics.xml
@@ -69,6 +69,13 @@
                 android:icon="@drawable/ic_connection"
                 android:text="@string/create_vm_display_backend" />
 
+            <cn.classfun.droidvm.ui.widgets.row.SwitchRowWidget
+                android:id="@+id/sw_native_display_enabled"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:icon="@drawable/ic_monitor"
+                android:text="@string/create_vm_native_display_enabled" />
+
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/menu/menu_native_display_menu.xml
+++ b/app/src/main/res/menu/menu_native_display_menu.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/menu_keyboard"
+        android:icon="@drawable/ic_keyboard"
+        android:title="@string/vnc_menu_keyboard" />
+
+    <item
+        android:id="@+id/menu_extra_keys"
+        android:icon="@drawable/ic_keyboard_esc"
+        android:title="@string/vnc_menu_extra_keys" />
+
+    <item
+        android:id="@+id/menu_fullscreen"
+        android:icon="@drawable/ic_fullscreen"
+        android:title="@string/vnc_menu_fullscreen" />
+
+</menu>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -132,6 +132,7 @@
     <string name="vm_info_console_not_found">找不到任何控制台</string>
     <string name="vm_info_console_text_select">文字控制台 %1$s</string>
     <string name="vm_info_console_vnc_select">VNC 控制台</string>
+    <string name="vm_info_console_native_select">原生显示</string>
     <string name="vm_info_console_vnc_ext_select">外部显示器的 VNC</string>
 
     <string name="vm_info_logs">日志</string>
@@ -204,6 +205,7 @@
     <string name="create_vm_display_dpi_v">垂直DPI</string>
     <string name="create_vm_category_vnc">VNC 服务器</string>
     <string name="create_vm_vnc_enabled">启用 VNC</string>
+    <string name="create_vm_native_display_enabled">启用原生显示 (virtio-gpu)</string>
     <string name="create_vm_vnc_host">主机地址</string>
     <string name="create_vm_vnc_port">端口</string>
     <string name="create_vm_vnc_password_auth">密码认证</string>
@@ -692,6 +694,12 @@
     <string name="vnc_display_reconnect_failed">重连失败，已尝试 %1$d 次</string>
     <string name="vnc_display_connect_failed">无法连接到 VNC 服务器</string>
     <string name="vnc_display_fullscreen">全屏</string>
+
+    <string name="native_display_title">原生显示器</string>
+    <string name="native_display_connecting">正在连接…</string>
+    <string name="native_display_waiting">正在等待虚拟机画面…</string>
+    <string name="native_display_connected">已连接 - %1$dx%2$d</string>
+    <string name="native_display_failed">原生显示启动失败</string>
 
     <string name="vnc_menu_keyboard">软键盘</string>
     <string name="vnc_menu_extra_keys">额外按键</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -135,6 +135,7 @@
     <string name="vm_info_console_text_select">Text Console %1$s</string>
     <string name="vm_info_console_vnc_select">VNC Console</string>
     <string name="vm_info_console_vnc_ext_select">VNC on external Display</string>
+    <string name="vm_info_console_native_select">Native Display</string>
 
     <string name="vm_info_logs">Logs</string>
     <string name="vm_info_logs_chooser_title">View Logs</string>
@@ -206,6 +207,7 @@
     <string name="create_vm_display_dpi_v">DPI Vertical</string>
     <string name="create_vm_category_vnc">VNC Server</string>
     <string name="create_vm_vnc_enabled">Enable VNC</string>
+    <string name="create_vm_native_display_enabled">Enable native display (virtio-gpu)</string>
     <string name="create_vm_vnc_host">Host</string>
     <string name="create_vm_vnc_port">Port</string>
     <string name="create_vm_vnc_password_auth">Password Auth</string>
@@ -731,6 +733,12 @@
     <string name="vnc_display_reconnect_failed">Reconnect failed after %1$d attempts</string>
     <string name="vnc_display_connect_failed">Failed to connect to VNC server</string>
     <string name="vnc_display_fullscreen">Fullscreen</string>
+
+    <string name="native_display_title">Native Display</string>
+    <string name="native_display_connecting">Connecting…</string>
+    <string name="native_display_waiting">Waiting for VM display…</string>
+    <string name="native_display_connected">Connected - %1$dx%2$d</string>
+    <string name="native_display_failed">Failed to start native display</string>
 
     <string name="vnc_menu_keyboard">Soft Keyboard</string>
     <string name="vnc_menu_extra_keys">Extra Keys</string>


### PR DESCRIPTION
This pull request introduces native display support for crosvm-based VMs, enabling direct rendering of guest displays to Android surfaces and forwarding input events from the UI to the guest via secure, root-brokered channels. Key changes include new AIDL interfaces, a root service for privileged operations, input forwarding mechanisms, and backend enhancements to manage native display input sockets.

**Native Display Integration and Input Forwarding**

* Added new AIDL interfaces for native display:
  * `ICrosvmAndroidDisplayService.aidl` defines the interface for crosvm's Android display backend, including methods to set surfaces and retrieve display configuration.
  * `DisplayConfig.aidl` describes the guest display configuration returned by crosvm.
  * `INativeDisplayRootService.aidl` provides a root-brokered interface for the UI to obtain crosvm display binders and forward input events securely.

* Introduced `NativeDisplayRootService`:
  * Implements privileged operations (as root) to look up crosvm display binder services and forward input events from the UI to the daemon’s per-VM input sockets, handling connection management and SELinux constraints.
  * Registered the new service and activity in `AndroidManifest.xml`.

**Daemon and Backend Enhancements**

* Added input forwarding handler and plumbing:
  * `InputHandler` (daemon-side) receives UI input requests, decodes them, and forwards the evdev bytes to the appropriate VM instance.
  * Added `writeNativeInput` methods to `VMInstance` and `VMBackendInstance` to abstract input delivery to the backend. [[1]](diffhunk://#diff-203df65dc4e4c1c79314ee8513f8aa145da899dd6ed9c3ee74289b5efa9a695aR84-R88) [[2]](diffhunk://#diff-b93e007f8952c7cf175081245488442b84f845e13a61a39f4de7945a779177e0R28-R35)

* Extended `CrosvmBackendInstance` for native display:
  * Manages per-VM native display input sockets via a new `NativeDisplayInputBridge`, pre-binding sockets before crosvm starts and releasing them on cleanup. [[1]](diffhunk://#diff-d076fff44d87fee083c07a9a89f31da8f2929657a94ee4c089a486b18f8868aaR52-R53) [[2]](diffhunk://#diff-d076fff44d87fee083c07a9a89f31da8f2929657a94ee4c089a486b18f8868aaR91-R100) [[3]](diffhunk://#diff-d076fff44d87fee083c07a9a89f31da8f2929657a94ee4c089a486b18f8868aaR123) [[4]](diffhunk://#diff-d076fff44d87fee083c07a9a89f31da8f2929657a94ee4c089a486b18f8868aaR461-R472)
  * Builds crosvm command-line arguments for native display and input sockets, ensuring correct configuration and gating on feature flags.

**Networking and Miscellaneous**

* Disabled Nagle’s algorithm on accepted daemon sockets to reduce UI response latency, especially for input acknowledgments.

These changes collectively enable secure, efficient native display and input forwarding for crosvm VMs, improving performance and user experience while respecting Android security boundaries.Add AIDL interfaces: DisplayConfig, ICrosvmAndroidDisplayService, INativeDisplayRootService Implement NativeDisplayRootService for root-privileged display binder lookup and input forwarding Add NativeDisplayInputBridge to manage crosvm and UI-facing input sockets Implement native display UI components: VMNativeDisplayActivity, DisplayProvider, InputForwarder Add input encoding: EvdevEncoder, KeyCodeMapper, DirectInputSink, TouchScaleCalculator Add NativeDisplay config model for consistent service name and socket path generation Add vm_input IPC handler for daemon-side input processing with low-latency unix socket forwarding Enable TCP_NODELAY on daemon server sockets for improved response latency