### PR TITLE
feat(mthp): add mode selection for lend mTHP allocation

### DIFF
--- a/app/src/main/java/cn/classfun/droidvm/daemon/vm/backend/CrosvmBackendInstance.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/vm/backend/CrosvmBackendInstance.java
@@ -38,6 +38,7 @@ import cn.classfun.droidvm.lib.store.disk.DiskBus;
 import cn.classfun.droidvm.lib.store.vm.DisplayBackend;
 import cn.classfun.droidvm.lib.store.vm.GpuApi;
 import cn.classfun.droidvm.lib.store.vm.GpuBackend;
+import cn.classfun.droidvm.lib.store.vm.LendMthpMode;
 import cn.classfun.droidvm.lib.store.vm.NativeDisplay;
 import cn.classfun.droidvm.lib.store.vm.ProtectedVM;
 import cn.classfun.droidvm.lib.store.vm.SharedDirCache;
@@ -186,8 +187,18 @@ public final class CrosvmBackendInstance extends VMBackendInstance {
             args.add("--disable-sandbox");
         if (item.optBoolean("hugepages", true))
             args.add("--hugepages");
-        if (item.optBoolean("prepare_lend_mthp", true))
-            args.add("--prepare-lend-mthp");
+        switch (LendMthpMode.fromItem(item)) {
+            case SINGLE:
+                args.add("--prepare-lend-mthp-mode");
+                args.add("single");
+                break;
+            case CHUNKED:
+                args.add("--prepare-lend-mthp-mode");
+                args.add("chunked");
+                break;
+            default:
+                break;
+        }
         var boot = BootPlan.of(config);
         if (!boot.initrd.isEmpty()) {
             args.add("--initrd");

--- a/app/src/main/java/cn/classfun/droidvm/lib/store/vm/LendMthpMode.java
+++ b/app/src/main/java/cn/classfun/droidvm/lib/store/vm/LendMthpMode.java
@@ -1,0 +1,41 @@
+package cn.classfun.droidvm.lib.store.vm;
+
+import static cn.classfun.droidvm.lib.store.enums.Enums.optEnum;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+
+import cn.classfun.droidvm.R;
+import cn.classfun.droidvm.lib.store.base.DataItem;
+import cn.classfun.droidvm.lib.store.enums.StringEnum;
+
+public enum LendMthpMode implements StringEnum {
+    DISABLED(R.string.create_vm_prepare_lend_mthp_disabled),
+    SINGLE(R.string.create_vm_prepare_lend_mthp_single),
+    CHUNKED(R.string.create_vm_prepare_lend_mthp_chunked);
+
+    public static final String KEY = "prepare_lend_mthp";
+    public static final LendMthpMode DEFAULT = CHUNKED;
+
+    private final @StringRes int stringId;
+
+    LendMthpMode(@StringRes int stringId) {
+        this.stringId = stringId;
+    }
+
+    @Override
+    @StringRes
+    public int getStringId() {
+        return stringId;
+    }
+
+    // Resolves the mode from config, migrating the legacy boolean value
+    // (true -> chunked, false -> disabled) written by older versions.
+    @NonNull
+    public static LendMthpMode fromItem(@NonNull DataItem item) {
+        var raw = item.opt(KEY, null);
+        if (raw != null && raw.is(DataItem.Type.BOOLEAN))
+            return raw.asBoolean() ? CHUNKED : DISABLED;
+        return optEnum(item, KEY, DEFAULT);
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/ui/agent/base/AgentVM.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/agent/base/AgentVM.java
@@ -29,6 +29,7 @@ import cn.classfun.droidvm.lib.store.disk.DiskBus;
 import cn.classfun.droidvm.lib.store.disk.DiskConfig;
 import cn.classfun.droidvm.lib.store.disk.DiskStore;
 import cn.classfun.droidvm.lib.store.vm.BootConfig;
+import cn.classfun.droidvm.lib.store.vm.LendMthpMode;
 import cn.classfun.droidvm.lib.store.vm.SharedDirType;
 import cn.classfun.droidvm.lib.store.vm.VMConfig;
 import cn.classfun.droidvm.lib.utils.FileUtils;
@@ -108,7 +109,7 @@ public final class AgentVM implements JSONSerialize {
         vm.item.set("temporary", true);
         vm.item.set("cpu_count", 1);
         vm.item.set("memory_mb", 384);
-        vm.item.set("prepare_lend_mthp", false);
+        vm.item.set(LendMthpMode.KEY, LendMthpMode.DISABLED);
         var boot = BootConfig.of(vm);
         boot.setProtocol(BootConfig.Protocol.LINUX);
         boot.setLinuxSource(BootConfig.LinuxSource.MANUAL);

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/edit/basic/VMEditBasicTab.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/edit/basic/VMEditBasicTab.java
@@ -15,6 +15,7 @@ import com.google.android.material.textfield.TextInputEditText;
 
 import cn.classfun.droidvm.R;
 import cn.classfun.droidvm.lib.store.base.DataItem;
+import cn.classfun.droidvm.lib.store.vm.LendMthpMode;
 import cn.classfun.droidvm.lib.store.vm.ProtectedVM;
 import cn.classfun.droidvm.lib.store.vm.VMBackend;
 import cn.classfun.droidvm.lib.size.SizeUnit;
@@ -39,7 +40,7 @@ public final class VMEditBasicTab extends VMEditBaseTab {
     private SwitchRowWidget swUsb;
     private SwitchRowWidget swSandbox;
     private SwitchRowWidget swHugepages;
-    private SwitchRowWidget swPrepareLendMthp;
+    private ChooseRowWidget choosePrepareLendMthp;
     private ChooseRowWidget chooseProtectedVm;
     private ChooseRowWidget chooseBackend;
     private ChooseRowWidget chooseHypervisor;
@@ -62,7 +63,7 @@ public final class VMEditBasicTab extends VMEditBaseTab {
         swUsb = view.findViewById(R.id.sw_usb);
         swSandbox = view.findViewById(R.id.sw_sandbox);
         swHugepages = view.findViewById(R.id.sw_hugepages);
-        swPrepareLendMthp = view.findViewById(R.id.sw_prepare_lend_mthp);
+        choosePrepareLendMthp = view.findViewById(R.id.choose_prepare_lend_mthp);
         chooseProtectedVm = view.findViewById(R.id.choose_protected_vm);
         chooseBackend = view.findViewById(R.id.choose_backend);
         chooseHypervisor = view.findViewById(R.id.choose_hypervisor);
@@ -74,6 +75,7 @@ public final class VMEditBasicTab extends VMEditBaseTab {
         inputMemory.setValue(512, SizeUnit.MB);
         inputCpu.setValue(1);
         inputSwiotlb.setValue(64, SizeUnit.MB);
+        choosePrepareLendMthp.configure(LendMthpMode.class, LendMthpMode.DEFAULT);
         chooseProtectedVm.configure(ProtectedVM.class, PROTECTED_WITHOUT_FIRMWARE);
         chooseBackend.configure(VMBackend.class, VMBackend.DEFAULT);
         chooseHypervisor.configure(VMHypervisor.class, VMHypervisor.DEFAULT);
@@ -93,7 +95,7 @@ public final class VMEditBasicTab extends VMEditBaseTab {
         swUsb.setChecked(item.optBoolean("usb", false));
         swSandbox.setChecked(item.optBoolean("sandbox", false));
         swHugepages.setChecked(item.optBoolean("hugepages", false));
-        swPrepareLendMthp.setChecked(item.optBoolean("prepare_lend_mthp", true));
+        choosePrepareLendMthp.setSelectedItem(LendMthpMode.fromItem(item));
         chooseProtectedVm.setSelectedItem(optEnum(item, "protected_vm", PROTECTED_WITHOUT_FIRMWARE));
         chooseBackend.setSelectedItem(optEnum(item, "backend", VMBackend.DEFAULT));
         chooseHypervisor.setSelectedItem(optEnum(item, "hypervisor", VMHypervisor.DEFAULT));
@@ -187,7 +189,8 @@ public final class VMEditBasicTab extends VMEditBaseTab {
         item.set("usb", swUsb.isChecked());
         item.set("sandbox", swSandbox.isChecked());
         item.set("hugepages", swHugepages.isChecked());
-        item.set("prepare_lend_mthp", swPrepareLendMthp.isChecked());
+        LendMthpMode lendMthpMode = choosePrepareLendMthp.getSelectedItem();
+        item.set(LendMthpMode.KEY, lendMthpMode);
         ProtectedVM pvm = chooseProtectedVm.getSelectedItem();
         item.set("protected_vm", pvm);
         VMBackend backend = chooseBackend.getSelectedItem();

--- a/app/src/main/res/layout/partial_vm_edit_basic.xml
+++ b/app/src/main/res/layout/partial_vm_edit_basic.xml
@@ -103,11 +103,10 @@
             android:icon="@drawable/ic_memory"
             android:text="@string/create_vm_hugepages" />
 
-        <cn.classfun.droidvm.ui.widgets.row.SwitchRowWidget
-            android:id="@+id/sw_prepare_lend_mthp"
+        <cn.classfun.droidvm.ui.widgets.row.ChooseRowWidget
+            android:id="@+id/choose_prepare_lend_mthp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:checked="true"
             android:icon="@drawable/ic_preallocate"
             android:text="@string/create_vm_prepare_lend_mthp" />
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -181,6 +181,9 @@
     <string name="create_vm_sandbox">沙箱</string>
     <string name="create_vm_hugepages">大页内存</string>
     <string name="create_vm_prepare_lend_mthp">预分配大页</string>
+    <string name="create_vm_prepare_lend_mthp_disabled">禁用</string>
+    <string name="create_vm_prepare_lend_mthp_single">单次 (整块借出)</string>
+    <string name="create_vm_prepare_lend_mthp_chunked">分块 (≤256MiB)</string>
     <string name="create_vm_protected_normal">普通</string>
     <string name="create_vm_protected_protected">保护</string>
     <string name="create_vm_protected_without_firmware">无固件保护</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -183,6 +183,9 @@
     <string name="create_vm_sandbox">Sandbox</string>
     <string name="create_vm_hugepages">Hugepages</string>
     <string name="create_vm_prepare_lend_mthp">Prepare Lend mTHP</string>
+    <string name="create_vm_prepare_lend_mthp_disabled">Disabled</string>
+    <string name="create_vm_prepare_lend_mthp_single">Single (whole region)</string>
+    <string name="create_vm_prepare_lend_mthp_chunked">Chunked (≤256MiB)</string>
     <string name="create_vm_protected_normal">Normal</string>
     <string name="create_vm_protected_protected">Protected</string>
     <string name="create_vm_protected_without_firmware">Protected without firmware</string>


### PR DESCRIPTION
- Create LendMthpMode enum (DISABLED/SINGLE/CHUNKED) with backward-compat migration
- Migrate daemon CLI args from --prepare-lend-mthp boolean to --prepare-lend-mthp-mode
- Switch UI from binary toggle to three-way chooser in VMEditBasicTab
- Update AgentVM temporary VM to use LendMthpMode.DISABLED
- Add localized labels for all three lend mTHP modes