### PR TITLE
feat(vm): add guest reboot support

### DIFF
--- a/app/src/main/cpp/console/commands/console.cpp
+++ b/app/src/main/cpp/console/commands/console.cpp
@@ -43,6 +43,7 @@ private:
     );
 
     bool running = false;
+    bool rebooting = false;
 };
 
 void ConsoleCommand::console_list(const std::string &vm) {
@@ -94,12 +95,25 @@ void ConsoleCommand::process_event(
                 fflush(stdout);
             }
         }
-    } else if (event == "exited" || event == "state") {
+    } else if (event == "rebooting") {
+        // Guest-initiated reboot: the daemon tears down crosvm and relaunches it
+        // reusing the same console streams. Stay attached so the new boot's output
+        // streams in seamlessly instead of dropping the terminal.
+        rebooting = true;
+        fprintf(stderr, "\n[droidvm] VM rebooting...\n");
+    } else if (event == "exited") {
+        // The only authoritative terminal signal. Every non-reboot end path fires
+        // "exited" (with the real code); a bare "stopped" state during reboot does not.
+        int code = edata.get("exit_code", -1).asInt();
+        fprintf(stderr, "\n[droidvm] VM exited (code %d).\n", code);
+        running = false;
+    } else if (event == "state") {
         auto state = edata.get("state", "").asString();
-        if (state == "stopped") {
-            int code = edata.get("exit_code", -1).asInt();
-            fprintf(stderr, "\n[droidvm] VM exited (code %d).\n", code);
-            running = false;
+        // A "stopped" state event arrives during reboot too, so it is NOT terminal
+        // on its own - we wait for "exited". Just clear the reboot notice once back up.
+        if (state == "running" && rebooting) {
+            rebooting = false;
+            fprintf(stderr, "[droidvm] VM is back up.\n");
         }
     }
 }

--- a/app/src/main/java/cn/classfun/droidvm/daemon/ipc/vm/RebootHandler.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/ipc/vm/RebootHandler.java
@@ -1,0 +1,34 @@
+package cn.classfun.droidvm.daemon.ipc.vm;
+
+import static cn.classfun.droidvm.lib.utils.StringUtils.fmt;
+
+import androidx.annotation.NonNull;
+
+import com.google.auto.service.AutoService;
+
+import cn.classfun.droidvm.daemon.server.ClientRequest;
+import cn.classfun.droidvm.daemon.server.RequestException;
+import cn.classfun.droidvm.daemon.server.RequestHandler;
+
+@AutoService(RequestHandler.class)
+public final class RebootHandler extends RequestHandler {
+    @NonNull
+    @Override
+    public String getName() {
+        return "vm_reboot";
+    }
+
+    @Override
+    public void handle(@NonNull ClientRequest request) throws Exception {
+        var params = request.getParams();
+        var vmId = params.optString("vm_id", "");
+        if (vmId.isEmpty())
+            throw new RequestException("missing vm_id");
+        var vms = request.getContext().getVMs();
+        var inst = vms.findById(vmId);
+        if (inst == null)
+            throw new RequestException(fmt("VM not found: %s", vmId));
+        if (!inst.reboot())
+            throw new RequestException("failed to reboot VM");
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/daemon/vm/VMInstance.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/vm/VMInstance.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 
 import cn.classfun.droidvm.daemon.console.ConsoleStream;
 import cn.classfun.droidvm.daemon.vm.backend.BackendBase;
+import cn.classfun.droidvm.lib.data.CrosvmExit;
 import cn.classfun.droidvm.lib.natives.NativeProcess;
 import cn.classfun.droidvm.lib.natives.UnixHelper;
 import cn.classfun.droidvm.lib.store.base.DataItem;
@@ -45,6 +46,11 @@ public final class VMInstance extends VMConfig {
     private final VMInstanceStore store;
     private BootPlan bootPlan;
     private String bootEntryOverride;
+    private volatile boolean rebootRequested = false;
+
+    // Delay before relaunching on reboot: lets the kernel settle same-name TAP
+    // teardown/recreate and throttles a guest reboot-loop (no restart cap).
+    private static final long REBOOT_RELAUNCH_DELAY_MS = 500;
 
     public interface VMEventCallback {
         @SuppressWarnings("unused")
@@ -148,7 +154,9 @@ public final class VMInstance extends VMConfig {
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public boolean start() {
-        if (state != VMState.STOPPED) {
+        // REBOOTING is accepted too: the reboot relaunch calls start() from that
+        // transient state (process already gone) and goes straight to STARTING.
+        if (state != VMState.STOPPED && state != VMState.REBOOTING) {
             Log.w(TAG, fmt("VM %s is not stopped (state=%s), cannot start", getId(), state.name()));
             return false;
         }
@@ -277,6 +285,26 @@ public final class VMInstance extends VMConfig {
         return true;
     }
 
+    public boolean reboot() {
+        if (state != VMState.RUNNING) {
+            Log.w(TAG, fmt("Cannot reboot VM %s: state=%s", getId(), state.name()));
+            return false;
+        }
+        Log.i(TAG, fmt("Reboot requested for VM %s", getName()));
+        // crosvm has no reset control command, so reboot = ask crosvm to exit and
+        // let runVM() relaunch via the rebootRequested flag (kept set on fallback).
+        rebootRequested = true;
+        if (getBackendInstance().hasControlSocket()) {
+            if (runControlCommand("stop")) return true;
+            Log.w(TAG, fmt("Control stop failed for reboot of VM %s, falling back to destroy", getName()));
+        }
+        if (process != null && process.isAlive()) {
+            process.destroy();
+            shellKillProcess(process.pid());
+        }
+        return true;
+    }
+
     public boolean suspend() {
         if (state != VMState.RUNNING) {
             Log.w(TAG, fmt("Cannot suspend VM %s: state=%s", getId(), state.name()));
@@ -399,6 +427,9 @@ public final class VMInstance extends VMConfig {
             } catch (Exception ignored) {
             }
         }
+        // A guest-requested reset (crosvm exit 32) or a host-issued reboot both
+        // relaunch the VM; an explicit user stop never does and wins over both.
+        boolean wantRestart = !stoppedByUser && (code == CrosvmExit.RESET.getCode() || rebootRequested);
         if (stoppedByUser && code != 0) {
             Log.i(TAG, fmt("VM %s stopped by user", getName()));
             exitCode = 0;
@@ -407,8 +438,44 @@ public final class VMInstance extends VMConfig {
         }
         cleanupTap();
         inst.cleanup();
+        if (wantRestart) {
+            rebootRequested = false;
+            exitCode = -1;
+            // Broadcast REBOOTING (not STOPPED) so clients render "rebooting" for the
+            // whole relaunch window instead of flickering to a stopped row/button.
+            // start() accepts REBOOTING, so the next transition is straight to STARTING.
+            setState(VMState.REBOOTING);
+            fireEvent("rebooting", null);
+            Log.i(TAG, fmt("VM %s rebooting (exit code %d)", getName(), code));
+            scheduleRelaunch();
+            return;
+        }
         setState(VMState.STOPPED);
         fireEvent("exited", null);
+    }
+
+    // Relaunch off the worker thread: start() joins workerThread (this thread),
+    // and the short sleep settles same-name TAP recreation before re-setup.
+    private void scheduleRelaunch() {
+        var t = new Thread(() -> {
+            try {
+                Thread.sleep(REBOOT_RELAUNCH_DELAY_MS);
+            } catch (InterruptedException ignored) {
+                return;
+            }
+            if (state != VMState.REBOOTING) return; // user changed state meanwhile
+            if (!start()) {
+                Log.w(TAG, fmt("VM %s relaunch failed", getName()));
+                // Surface the failure as a real exit so attached consoles / UI stop
+                // waiting for the reboot to come back. start() left us in REBOOTING,
+                // so settle to STOPPED before the exit fires the correct final state.
+                exitCode = -1;
+                setState(VMState.STOPPED);
+                fireEvent("exited", null);
+            }
+        }, fmt("VM-relaunch-%s", getId()));
+        t.setDaemon(true);
+        t.start();
     }
 
     private void cleanupTap() {

--- a/app/src/main/java/cn/classfun/droidvm/daemon/vm/backend/CrosvmBackendInstance.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/vm/backend/CrosvmBackendInstance.java
@@ -136,6 +136,9 @@ public final class CrosvmBackendInstance extends VMBackendInstance {
         var args = new ArrayList<String>();
         prepareStraceArguments(args);
         args.add(getPrebuiltBinaryPath("crosvm"));
+        // Top-level flag (must precede `run`): makes crosvm surface CommandStatus
+        // exit codes (see CrosvmExit) so runVM() can tell reset/crash/panic apart.
+        args.add("--extended-status");
         args.add("run");
         args.add("--name");
         args.add(config.getName());

--- a/app/src/main/java/cn/classfun/droidvm/lib/daemon/VMEventHandler.java
+++ b/app/src/main/java/cn/classfun/droidvm/lib/daemon/VMEventHandler.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.UUID;
 
 import cn.classfun.droidvm.R;
+import cn.classfun.droidvm.lib.data.CrosvmExit;
 import cn.classfun.droidvm.lib.diag.LogHelper;
 import cn.classfun.droidvm.lib.store.vm.VMState;
 import cn.classfun.droidvm.lib.store.vm.VMStore;
@@ -92,6 +93,24 @@ public final class VMEventHandler implements
             c.onVMExited(vmId, vmName, exitCode, data);
     }
 
+    /** Maps a crosvm exit code to a user-facing message resource (args: vmName, code). */
+    public static int exitMessageRes(int exitCode) {
+        CrosvmExit exit = CrosvmExit.fromCode(exitCode);
+        if (exit == null) {
+            return R.string.vm_exited_error;
+        }
+        switch (exit) {
+            case CRASH:
+                return R.string.vm_exit_crash;
+            case GUEST_PANIC:
+                return R.string.vm_exit_guest_panic;
+            case WATCHDOG:
+                return R.string.vm_exit_watchdog;
+            default:
+                return R.string.vm_exited_error;
+        }
+    }
+
     private void showExitDialog(Activity act, String vmName, int exitCode, @NonNull JSONObject data) {
         var logText = new StringBuilder();
         var stdio = data.optString("stdio", "");
@@ -140,7 +159,7 @@ public final class VMEventHandler implements
             } else {
                 Toast.makeText(
                     act,
-                    act.getString(R.string.vm_exited_error, vmName, exitCode),
+                    act.getString(exitMessageRes(exitCode), vmName, exitCode),
                     LENGTH_LONG
                 ).show();
                 showExitDialog(act, vmName, exitCode, data);
@@ -169,6 +188,10 @@ public final class VMEventHandler implements
                 if (foregroundCallback.isEmpty() || !isAppInForeground())
                     showExitNotification(vmId, vmName, exitCode);
                 callOnVmExited(vmId, vmName, exitCode, data);
+            } else if (event.equals("rebooting")) {
+                queueActivityTask(act -> Toast.makeText(
+                    act, act.getString(R.string.vm_rebooting, vmName), LENGTH_SHORT
+                ).show(), SplashActivity.class);
             }
         });
     }

--- a/app/src/main/java/cn/classfun/droidvm/lib/data/CrosvmExit.java
+++ b/app/src/main/java/cn/classfun/droidvm/lib/data/CrosvmExit.java
@@ -1,0 +1,32 @@
+package cn.classfun.droidvm.lib.data;
+
+/**
+ * crosvm process exit codes (CommandStatus). RESET drives the automatic relaunch
+ * in VMInstance; the rest are surfaced to the user as distinct failure reasons.
+ */
+public enum CrosvmExit {
+    RESET(32),        // VmReset: guest requested reboot/reset
+    CRASH(33),        // VmCrash
+    GUEST_PANIC(34),  // kernel panic in guest
+    WATCHDOG(36);     // vcpu stall / watchdog reset
+
+    private final int code;
+
+    CrosvmExit(int code) {
+        this.code = code;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    /** Maps a raw crosvm exit code to its constant, or null when unrecognized. */
+    public static CrosvmExit fromCode(int code) {
+        for (CrosvmExit exit : values()) {
+            if (exit.code == code) {
+                return exit;
+            }
+        }
+        return null;
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/lib/store/vm/VMState.java
+++ b/app/src/main/java/cn/classfun/droidvm/lib/store/vm/VMState.java
@@ -27,6 +27,10 @@ public enum VMState implements StringEnum, ColorEnum {
     STOPPING(
         R.string.vm_state_stopping,
         android.R.color.holo_orange_dark
+    ),
+    REBOOTING(
+        R.string.vm_state_rebooting,
+        android.R.color.holo_orange_dark
     );
 
     private final @StringRes int stringId;

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/info/VMInfoActivity.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/info/VMInfoActivity.java
@@ -44,6 +44,7 @@ import cn.classfun.droidvm.DroidVMApp;
 import cn.classfun.droidvm.R;
 import cn.classfun.droidvm.lib.daemon.DaemonConnection;
 import cn.classfun.droidvm.lib.daemon.ForegroundCallback;
+import cn.classfun.droidvm.lib.daemon.VMEventHandler;
 import cn.classfun.droidvm.lib.store.base.DataItem;
 import cn.classfun.droidvm.lib.store.network.NetworkStore;
 import cn.classfun.droidvm.lib.store.vm.BootConfig;
@@ -204,7 +205,7 @@ public final class VMInfoActivity extends AppCompatActivity implements Foregroun
                 ).show();
             } else {
                 Toast.makeText(this,
-                    getString(R.string.vm_exited_error, vmName, exitCode),
+                    getString(VMEventHandler.exitMessageRes(exitCode), vmName, exitCode),
                     LENGTH_LONG
                 ).show();
             }
@@ -431,9 +432,10 @@ public final class VMInfoActivity extends AppCompatActivity implements Foregroun
     }
 
     private void doRestart() {
+        // crosvm reboot: daemon stops crosvm and relaunches it (no client-side
+        // stop+delay+start); a guest-initiated reboot takes the same daemon path.
         DialogInterface.OnClickListener cb = (d, w) ->
-            sendCommand("vm_stop", vmId, mainHandler, ui,
-                () -> mainHandler.postDelayed(this::doStart, 1500));
+            sendCommand("vm_reboot", vmId, mainHandler, ui);
         new MaterialAlertDialogBuilder(this)
             .setTitle(config.getName())
             .setMessage(R.string.vm_info_restart_confirm)

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -107,9 +107,14 @@
     <string name="vm_state_starting">启动中</string>
     <string name="vm_state_running">运行中</string>
     <string name="vm_state_stopping">停止中</string>
+    <string name="vm_state_rebooting">重启中</string>
 
     <string name="vm_exited_success">虚拟机"%1$s"已停止。</string>
     <string name="vm_exited_error">虚拟机"%1$s"以退出码 %2$d 退出。</string>
+    <string name="vm_exit_crash">虚拟机"%1$s"已崩溃（退出码 %2$d）。</string>
+    <string name="vm_exit_guest_panic">虚拟机"%1$s"guest 内核 panic（退出码 %2$d）。</string>
+    <string name="vm_exit_watchdog">虚拟机"%1$s"卡死，已被看门狗复位（退出码 %2$d）。</string>
+    <string name="vm_rebooting">正在重启虚拟机"%1$s"…</string>
     <string name="vm_exit_dialog_title">虚拟机"%1$s"启动失败</string>
     <string name="vm_exit_dialog_message">虚拟机以退出码 %1$d 退出。\n\n日志：</string>
     <string name="vm_exit_no_logs">无可用日志。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -107,6 +107,7 @@
     <string name="vm_state_starting">啟動中</string>
     <string name="vm_state_running">執行中</string>
     <string name="vm_state_stopping">停止中</string>
+    <string name="vm_state_rebooting">重新啟動中</string>
 
     <string name="vm_exited_success">虛擬機器"%1$s"已停止。</string>
     <string name="vm_exited_error">虛擬機器"%1$s"以退出碼 %2$d 退出。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,9 +108,14 @@
     <string name="vm_state_starting">Starting</string>
     <string name="vm_state_running">Running</string>
     <string name="vm_state_stopping">Stopping</string>
+    <string name="vm_state_rebooting">Rebooting</string>
 
     <string name="vm_exited_success">VM \"%1$s\" has stopped.</string>
     <string name="vm_exited_error">VM \"%1$s\" exited with code %2$d.</string>
+    <string name="vm_exit_crash">VM \"%1$s\" crashed (code %2$d).</string>
+    <string name="vm_exit_guest_panic">VM \"%1$s\" hit a kernel panic in the guest (code %2$d).</string>
+    <string name="vm_exit_watchdog">VM \"%1$s\" stalled and was reset by the watchdog (code %2$d).</string>
+    <string name="vm_rebooting">Rebooting VM \"%1$s\"…</string>
     <string name="vm_exit_dialog_title">VM \"%1$s\" Failed</string>
     <string name="vm_exit_dialog_message">The virtual machine exited with code %1$d.\n\nLogs:</string>
     <string name="vm_exit_no_logs">No logs available.</string>


### PR DESCRIPTION
- Implement vm_reboot IPC command and RebootHandler
- Add REBOOTING state and rebooting event in daemon-client communication
- Support crosvm exit code detection (--extended-status flag)
- Add CrosvmExit constants to distinguish reset from crash/panic/watchdog
- Implement automatic VM relaunch on guest-requested reset (code 32)
- Update console to track reboot state and show seamless relaunch
- Update UI to use vm_reboot instead of stop+delay+start sequence
- Add localized strings for reboot state and exit reasons