### PR TITLE
feat: add multi-volume split for vm package export/import

### DIFF
--- a/app/src/main/java/cn/classfun/droidvm/daemon/ipc/vm/ExportHandler.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/ipc/vm/ExportHandler.java
@@ -8,6 +8,7 @@ import cn.classfun.droidvm.daemon.server.ClientRequest;
 import cn.classfun.droidvm.daemon.server.RequestException;
 import cn.classfun.droidvm.daemon.server.RequestHandler;
 import cn.classfun.droidvm.daemon.vm.pkg.VMExportTask;
+import cn.classfun.droidvm.lib.pkg.PackageConstants;
 
 @AutoService(RequestHandler.class)
 public final class ExportHandler extends RequestHandler {
@@ -25,6 +26,12 @@ public final class ExportHandler extends RequestHandler {
             throw new RequestException("missing vm_id");
         if (destPath.isEmpty())
             throw new RequestException("missing dest_path");
+        var volumeSize = params.optLong("volume_size", 0);
+        if (volumeSize > 0 && volumeSize < PackageConstants.MIN_VOLUME_SIZE)
+            throw new RequestException(String.format(
+                "volume_size too small: %d (min %d)",
+                volumeSize, PackageConstants.MIN_VOLUME_SIZE
+            ));
         var store = request.getContext().getExportTaskStore();
         var server = request.getClient().getServer();
         var task = new VMExportTask(server, params);

--- a/app/src/main/java/cn/classfun/droidvm/daemon/vm/pkg/VMExportTask.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/vm/pkg/VMExportTask.java
@@ -36,6 +36,8 @@ import cn.classfun.droidvm.lib.pkg.DiskRef;
 import cn.classfun.droidvm.lib.pkg.PackageConstants;
 import cn.classfun.droidvm.lib.pkg.PackageManifest;
 import cn.classfun.droidvm.lib.pkg.Phase;
+import cn.classfun.droidvm.lib.pkg.VolumeIndex;
+import cn.classfun.droidvm.lib.pkg.VolumeSplitOutputStream;
 import cn.classfun.droidvm.lib.store.base.DataItem;
 
 public final class VMExportTask {
@@ -47,6 +49,9 @@ public final class VMExportTask {
     private final UUID sourceVMId;
     private final int totalItems;
     private final String destPath;
+    private final long volumeSize;
+    private VolumeSplitOutputStream vout = null;
+    private int finalVolumeCount = 0;
 
     public VMExportTask(
         @NonNull Server server,
@@ -56,6 +61,7 @@ public final class VMExportTask {
         destPath = request.optString("dest_path");
         if (!destPath.startsWith("/"))
             throw new IllegalArgumentException("missing dest_path");
+        volumeSize = request.optLong("volume_size", 0);
         var vmId = UUID.fromString(request.optString("vm_id"));
         sourceVMId = vmId;
         var vm = server.getContext().getVMs().findById(vmId);
@@ -91,6 +97,10 @@ public final class VMExportTask {
             try {
                 startWrite();
                 data.set("done", totalItems);
+                if (finalVolumeCount > 0) {
+                    data.set("volume_index", finalVolumeCount);
+                    data.set("volume_total", finalVolumeCount);
+                }
                 emit(data, Phase.DONE);
             } catch (Exception e) {
                 Log.w(TAG, fmt("Export task %s failed", taskId), e);
@@ -105,6 +115,11 @@ public final class VMExportTask {
     }
 
     private void startWrite() throws Exception {
+        if (volumeSize > 0) startWriteSplit();
+        else startWriteSingle();
+    }
+
+    private void startWriteSingle() throws Exception {
         var outFile = new File(destPath);
         var manifestBytes = manifest.toJson().toString(4).getBytes(UTF_8);
         if (manifestBytes.length > 0xffff)
@@ -129,6 +144,75 @@ public final class VMExportTask {
             writeZero(raf, alignUp(dataEnd) - dataEnd);
             raf.seek(0);
             raf.write(buildHeader(manifest, manifestBytes.length, dataSize));
+        }
+    }
+
+    // Multi-volume path: (1) slice the compressed data stream into <dest>.001,
+    // .002, ... sub-volumes, then (2) write the metadata master <dest> holding
+    // header + manifest + volume index (no data). The picked SAF file is reused
+    // as the master, so it is not deleted.
+    private void startWriteSplit() throws Exception {
+        var manifestBytes = manifest.toJson().toString(4).getBytes(UTF_8);
+        if (manifestBytes.length > 0xffff)
+            throw new IOException(fmt("manifest too large: %d bytes", manifestBytes.length));
+        var subOut = new VolumeSplitOutputStream(destPath, volumeSize);
+        vout = subOut;
+        try {
+            try (
+                var compressed = wrapCompressionOutput(subOut, manifest.compression);
+                var tar = new TarWriter(compressed)
+            ) {
+                tar.entry(PackageConstants.MANIFEST_NAME, manifestBytes);
+                pack(tar);
+            }
+            subOut.finish();
+        } catch (Exception e) {
+            subOut.abort();
+            deleteQuietly(subOut.files());
+            throw e;
+        } finally {
+            vout = null;
+        }
+        long dataSize = subOut.dataSize();
+        finalVolumeCount = subOut.volumeCount();
+        writeMaster(manifestBytes, dataSize, subOut);
+        // Remove any higher-numbered sub-volumes left by a previous, larger
+        // export to the same base path, so the on-disk set matches the index.
+        for (int i = finalVolumeCount + 1; i <= PackageConstants.VOLUME_MAX_COUNT; i++) {
+            var stale = new File(VolumeSplitOutputStream.volumeName(destPath, i));
+            if (!stale.exists()) break;
+            //noinspection ResultOfMethodCallIgnored
+            stale.delete();
+        }
+    }
+
+    private static void deleteQuietly(@NonNull java.util.List<File> files) {
+        for (var f : files) {
+            //noinspection ResultOfMethodCallIgnored
+            f.delete();
+        }
+    }
+
+    private void writeMaster(
+        @NonNull byte[] manifestBytes,
+        long dataSize,
+        @NonNull VolumeSplitOutputStream subOut
+    ) throws Exception {
+        var index = new VolumeIndex();
+        index.dataSize = dataSize;
+        index.volumes.addAll(subOut.entries());
+        var indexBytes = index.toJson().toString().getBytes(UTF_8);
+        try (var raf = new RandomAccessFile(new File(destPath), "rw")) {
+            raf.setLength(0);
+            raf.write(new byte[PackageConstants.HEADER_SIZE]);
+            writeZero(raf, alignUp(raf.getFilePointer()) - raf.getFilePointer());
+            raf.write(manifestBytes);
+            writeZero(raf, alignUpStrict(raf.getFilePointer()) - raf.getFilePointer());
+            raf.write(indexBytes);
+            raf.seek(0);
+            raf.write(buildHeader(
+                manifest, manifestBytes.length, dataSize, finalVolumeCount
+            ));
         }
     }
 
@@ -209,6 +293,9 @@ public final class VMExportTask {
             data.put("phase", phase.name().toLowerCase());
             data.put("vm_id", sourceVMId.toString());
             data.put("vm_name", manifest.vm.getName());
+            var out = vout;
+            if (out != null && !data.has("volume_index"))
+                data.put("volume_index", out.currentIndex());
             var ev = new JSONObject();
             ev.put("type", "event");
             ev.put("data", data);

--- a/app/src/main/java/cn/classfun/droidvm/daemon/vm/pkg/VMExportUtils.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/vm/pkg/VMExportUtils.java
@@ -59,6 +59,16 @@ public final class VMExportUtils {
         int manifestSize,
         long dataSize
     ) throws IOException {
+        return buildHeader(manifest, manifestSize, dataSize, 0);
+    }
+
+    @NonNull
+    public static byte[] buildHeader(
+        @NonNull PackageManifest manifest,
+        int manifestSize,
+        long dataSize,
+        int volumeCount
+    ) throws IOException {
         var hdr = new byte[PackageConstants.HEADER_SIZE];
         var magic = PackageConstants.MAGIC.getBytes(UTF_8);
         System.arraycopy(magic, 0, hdr, 0, magic.length);
@@ -66,6 +76,7 @@ public final class VMExportUtils {
         putUInt16LE(hdr, 8, BuildConfig.VERSION_CODE);
         putUInt16LE(hdr, 10, manifestSize);
         putUInt16LE(hdr, 12, manifest.compression.type);
+        putUInt16LE(hdr, 14, volumeCount);
         putInt64LE(hdr, 16, dataSize);
         return hdr;
     }

--- a/app/src/main/java/cn/classfun/droidvm/daemon/vm/pkg/VMImportTask.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/vm/pkg/VMImportTask.java
@@ -4,6 +4,7 @@ import static cn.classfun.droidvm.daemon.vm.pkg.VMImportUtils.remapBootPaths;
 import static cn.classfun.droidvm.daemon.vm.pkg.VMImportUtils.remapDiskPaths;
 import static cn.classfun.droidvm.daemon.vm.pkg.VMImportUtils.uniqueFile;
 import static cn.classfun.droidvm.lib.pkg.PackageConstants.BUFFER;
+import static cn.classfun.droidvm.lib.utils.BinaryUtils.readFully;
 import static cn.classfun.droidvm.lib.utils.JsonUtils.listToJSONArray;
 import static cn.classfun.droidvm.lib.utils.StringUtils.basename;
 import static cn.classfun.droidvm.lib.utils.StringUtils.fmt;
@@ -31,9 +32,12 @@ import cn.classfun.droidvm.daemon.server.Server;
 import cn.classfun.droidvm.lib.archive.TarReader;
 import cn.classfun.droidvm.lib.pkg.BootFile;
 import cn.classfun.droidvm.lib.pkg.DiskEntry;
+import cn.classfun.droidvm.lib.pkg.PackageConstants;
+import cn.classfun.droidvm.lib.pkg.PackageHeader;
 import cn.classfun.droidvm.lib.pkg.PackageInput;
 import cn.classfun.droidvm.lib.pkg.PackageManifest;
 import cn.classfun.droidvm.lib.pkg.Phase;
+import cn.classfun.droidvm.lib.pkg.VolumeSet;
 import cn.classfun.droidvm.lib.store.base.DataItem;
 import cn.classfun.droidvm.lib.store.network.NetworkConfig;
 import cn.classfun.droidvm.lib.store.vm.VMConfig;
@@ -47,6 +51,7 @@ public final class VMImportTask {
     private final File targetDir;
     private final String networkMode;
     private int totalItems;
+    private int volumeTotal = 0;
     public VMConfig importedVM = null;
     public PackageManifest importedManifest = null;
     public final ArrayList<DiskEntry> placedDisks = new ArrayList<>();
@@ -125,28 +130,53 @@ public final class VMImportTask {
     private void unpack() throws Exception {
         if (!targetDir.exists() && !targetDir.mkdirs())
             throw new IOException(fmt("Cannot create target dir: %s", targetDir));
-        try (
-            var in = new FileInputStream(srcPath);
-            var pkg = PackageInput.open(in)
-        ) {
-            importedManifest = pkg.manifest;
-            totalItems = importedManifest.disks.size() + importedManifest.boots.size();
-            var data = DataItem.newObject();
-            data.set("done", 0);
-            data.set("total", totalItems);
-            emit(data, Phase.PACK);
-            var tar = new TarReader(pkg.data);
-            tar.forEach(this::onTarItem);
-            var buf = new byte[BUFFER];
-            //noinspection StatementWithEmptyBody
-            while (pkg.data.read(buf) >= 0);
-            pkg.validateDataConsumed();
+        // Any picked path maps to its metadata master (strip a .NNN suffix).
+        var masterPath = VolumeSet.masterOf(srcPath);
+        if (readVolumeCount(masterPath) > 0) {
+            var set = VolumeSet.discover(masterPath);
+            volumeTotal = set.count();
+            try (
+                var in = set.openLogicalStream();
+                var pkg = PackageInput.open(in, set.dataSize())
+            ) {
+                extract(pkg);
+            }
+        } else {
+            try (
+                var in = new FileInputStream(masterPath);
+                var pkg = PackageInput.open(in)
+            ) {
+                extract(pkg);
+            }
         }
         var vm = new VMConfig(importedManifest.vm.toJson());
         vm.setId(UUID.randomUUID());
         remapDiskPaths(vm, placedDisks);
         remapBootPaths(vm, placedBoots);
         importedVM = vm;
+    }
+
+    private int readVolumeCount(@NonNull String masterPath) throws Exception {
+        try (var in = new FileInputStream(masterPath)) {
+            var hdr = new byte[PackageConstants.HEADER_SIZE];
+            readFully(in, hdr);
+            return PackageHeader.fromBytes(hdr).volumeCount;
+        }
+    }
+
+    private void extract(@NonNull PackageInput pkg) throws Exception {
+        importedManifest = pkg.manifest;
+        totalItems = importedManifest.disks.size() + importedManifest.boots.size();
+        var data = DataItem.newObject();
+        data.set("done", 0);
+        data.set("total", totalItems);
+        emit(data, Phase.PACK);
+        var tar = new TarReader(pkg.data);
+        tar.forEach(this::onTarItem);
+        var buf = new byte[BUFFER];
+        //noinspection StatementWithEmptyBody
+        while (pkg.data.read(buf) >= 0);
+        pkg.validateDataConsumed();
     }
 
     @NonNull
@@ -281,6 +311,7 @@ public final class VMImportTask {
             data.put("event", "vm_import_status");
             data.put("task_id", taskId.toString());
             data.put("phase", phase.name().toLowerCase());
+            if (volumeTotal > 0) data.put("volume_total", volumeTotal);
             var ev = new JSONObject();
             ev.put("type", "event");
             ev.put("data", data);

--- a/app/src/main/java/cn/classfun/droidvm/lib/archive/ZeroInputStream.java
+++ b/app/src/main/java/cn/classfun/droidvm/lib/archive/ZeroInputStream.java
@@ -1,0 +1,31 @@
+package cn.classfun.droidvm.lib.archive;
+
+import androidx.annotation.NonNull;
+
+import java.io.InputStream;
+import java.util.Arrays;
+
+/** A bounded stream of zero bytes, used to reproduce trailing alignment padding. */
+public final class ZeroInputStream extends InputStream {
+    private long remaining;
+
+    public ZeroInputStream(long count) {
+        this.remaining = Math.max(0, count);
+    }
+
+    @Override
+    public int read() {
+        if (remaining <= 0) return -1;
+        remaining--;
+        return 0;
+    }
+
+    @Override
+    public int read(@NonNull byte[] b, int off, int len) {
+        if (remaining <= 0) return -1;
+        int n = (int) Math.min(len, remaining);
+        Arrays.fill(b, off, off + n, (byte) 0);
+        remaining -= n;
+        return n;
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/lib/pkg/PackageConstants.java
+++ b/app/src/main/java/cn/classfun/droidvm/lib/pkg/PackageConstants.java
@@ -12,6 +12,17 @@ public final class PackageConstants {
     public static final String MANIFEST_NAME = "manifest.json";
     public static final Compression DEFAULT_COMPRESSION = Compression.ZSTD;
 
+    // Multi-volume split. The picked file <base> stays as a small metadata
+    // master (header + manifest + volume index); the compressed data stream is
+    // sliced across <base>.001, <base>.002, ... sub-volumes. volume_size <= 0
+    // keeps the legacy single self-contained file (volumeCount == 0).
+    public static final long DEFAULT_VOLUME_SIZE = 500L * 1024 * 1024;
+    public static final long MIN_VOLUME_SIZE = 16L * 1024 * 1024;
+    public static final String VOLUME_MAGIC = "VMPV";
+    public static final int VOLUME_VERSION = 1;
+    public static final int VOLUME_MAX_COUNT = 999;
+    public static final int VOLUME_SUFFIX_DIGITS = 3;
+
     private PackageConstants() {
     }
 }

--- a/app/src/main/java/cn/classfun/droidvm/lib/pkg/PackageHeader.java
+++ b/app/src/main/java/cn/classfun/droidvm/lib/pkg/PackageHeader.java
@@ -18,6 +18,9 @@ public final class PackageHeader {
     public int appVersionCode = 0;
     public int manifestSize = 0;
     public int compression = 0;
+    // 0 = single self-contained file; > 0 = split package whose data lives in
+    // that many <base>.NNN sub-volumes (this file is the metadata master).
+    public int volumeCount = 0;
     public long dataSize = 0;
 
     public PackageHeader() {
@@ -32,6 +35,7 @@ public final class PackageHeader {
         appVersionCode = getUInt16LE(hdr, 8);
         manifestSize = getUInt16LE(hdr, 10);
         compression = getUInt16LE(hdr, 12);
+        volumeCount = getUInt16LE(hdr, 14);
         dataSize = getInt64LE(hdr, 16);
     }
 

--- a/app/src/main/java/cn/classfun/droidvm/lib/pkg/PackageInput.java
+++ b/app/src/main/java/cn/classfun/droidvm/lib/pkg/PackageInput.java
@@ -55,6 +55,16 @@ public final class PackageInput implements AutoCloseable {
 
     @NonNull
     public static PackageInput open(@NonNull InputStream raw) throws Exception {
+        return open(raw, -1);
+    }
+
+    /**
+     * Reads just the header and manifest for preview, without setting up the
+     * data/decompression stream. Safe on a metadata master (whose bytes after
+     * the manifest are the volume index, not compressed data).
+     */
+    @NonNull
+    public static PackageManifest peekManifest(@NonNull InputStream raw) throws Exception {
         var pkgHeader = PackageHeader.fromStream(raw);
         var manifest = PackageManifest.fromStream(raw, pkgHeader);
         if (pkgHeader.manifestVersion != manifest.manifestVersion)
@@ -63,6 +73,30 @@ public final class PackageInput implements AutoCloseable {
             throw new IOException("vmpkg app_version_code mismatch");
         if (pkgHeader.compression != manifest.compression.type)
             throw new IOException("vmpkg compression mismatch");
+        return manifest;
+    }
+
+    /**
+     * Opens a package, optionally overriding the data-region size. Multi-volume
+     * packages write a placeholder {@code dataSize} of 0 in the inline header
+     * (it is only known after streaming) and carry the real value in the volume
+     * trailer; pass it here as {@code dataSizeOverride}. Use -1 for the legacy
+     * single-file layout that patches its header in place.
+     */
+    @NonNull
+    public static PackageInput open(
+        @NonNull InputStream raw,
+        long dataSizeOverride
+    ) throws Exception {
+        var pkgHeader = PackageHeader.fromStream(raw);
+        var manifest = PackageManifest.fromStream(raw, pkgHeader);
+        if (pkgHeader.manifestVersion != manifest.manifestVersion)
+            throw new IOException("vmpkg manifest_version mismatch");
+        if (pkgHeader.appVersionCode != manifest.appVersionCode)
+            throw new IOException("vmpkg app_version_code mismatch");
+        if (pkgHeader.compression != manifest.compression.type)
+            throw new IOException("vmpkg compression mismatch");
+        if (dataSizeOverride >= 0) pkgHeader.dataSize = dataSizeOverride;
         long pos = alignUp(PackageConstants.HEADER_SIZE) + pkgHeader.manifestSize;
         readZeroPadding(raw, alignUpStrict(pos) - pos);
         var stream = new LimitedInputStream(raw, pkgHeader.dataSize);

--- a/app/src/main/java/cn/classfun/droidvm/lib/pkg/VolumeIndex.java
+++ b/app/src/main/java/cn/classfun/droidvm/lib/pkg/VolumeIndex.java
@@ -1,0 +1,94 @@
+package cn.classfun.droidvm.lib.pkg;
+
+import static cn.classfun.droidvm.lib.utils.JsonUtils.arrayToList;
+import static cn.classfun.droidvm.lib.utils.JsonUtils.listToJSONArray;
+import static cn.classfun.droidvm.lib.utils.StringUtils.fmt;
+
+import androidx.annotation.NonNull;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import cn.classfun.droidvm.lib.store.base.JSONSerialize;
+
+/**
+ * Volume list embedded in the metadata master ({@code <base>.vmpkg}) right
+ * after the manifest. It records the total data size and, for each sub-volume,
+ * its logical size and CRC32 so a reader can verify the set is complete and
+ * intact before unpacking. Plain JSON -- its length is master-file-size minus
+ * the data-region offset, so no framing/magic footer is needed.
+ */
+public final class VolumeIndex implements JSONSerialize {
+    public static final class Entry implements JSONSerialize {
+        public final int index;
+        public final long size;
+        public final long crc32;
+
+        public Entry(int index, long size, long crc32) {
+            this.index = index;
+            this.size = size;
+            this.crc32 = crc32;
+        }
+
+        public Entry(@NonNull JSONObject o) {
+            index = o.optInt("index");
+            size = o.optLong("size");
+            crc32 = o.optLong("crc32");
+        }
+
+        @NonNull
+        @Override
+        public JSONObject toJson() throws JSONException {
+            var o = new JSONObject();
+            o.put("index", index);
+            o.put("size", size);
+            o.put("crc32", crc32);
+            return o;
+        }
+
+        @NonNull
+        public static Entry from(Object o) throws JSONException {
+            if (o instanceof JSONObject)
+                return new Entry((JSONObject) o);
+            throw new JSONException("object is not json");
+        }
+    }
+
+    public int version = PackageConstants.VOLUME_VERSION;
+    public long dataSize = 0;
+    public final List<Entry> volumes = new ArrayList<>();
+
+    public VolumeIndex() {
+    }
+
+    public VolumeIndex(@NonNull JSONObject o) throws IOException, JSONException {
+        if (!PackageConstants.VOLUME_MAGIC.equals(o.optString("magic")))
+            throw new IOException("missing volume index magic");
+        version = o.optInt("version");
+        if (version != PackageConstants.VOLUME_VERSION)
+            throw new IOException(fmt("unsupported volume version: %d", version));
+        dataSize = o.optLong("data_size");
+        volumes.addAll(arrayToList(o, "volumes", Entry::from));
+        if (volumes.isEmpty())
+            throw new IOException("volume index has no volumes");
+    }
+
+    public VolumeIndex(@NonNull String json) throws IOException, JSONException {
+        this(new JSONObject(json));
+    }
+
+    @NonNull
+    @Override
+    public JSONObject toJson() throws JSONException {
+        var o = new JSONObject();
+        o.put("magic", PackageConstants.VOLUME_MAGIC);
+        o.put("version", version);
+        o.put("data_size", dataSize);
+        o.put("volumes", listToJSONArray(volumes));
+        return o;
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/lib/pkg/VolumeSet.java
+++ b/app/src/main/java/cn/classfun/droidvm/lib/pkg/VolumeSet.java
@@ -1,0 +1,220 @@
+package cn.classfun.droidvm.lib.pkg;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static cn.classfun.droidvm.lib.utils.BinaryUtils.alignUp;
+import static cn.classfun.droidvm.lib.utils.BinaryUtils.alignUpStrict;
+import static cn.classfun.droidvm.lib.utils.StringUtils.fmt;
+
+import androidx.annotation.NonNull;
+
+import org.json.JSONException;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Vector;
+import java.util.zip.CRC32;
+
+import cn.classfun.droidvm.lib.archive.ZeroInputStream;
+
+/**
+ * Reader-side view of a multi-volume vmpkg. Given the metadata master
+ * ({@code <base>.vmpkg}), it parses the embedded {@link VolumeIndex}, locates
+ * and validates the {@code <base>.001 ..} sub-volumes, then rebuilds the exact
+ * single-file byte stream -- {@code [master head][sub-volume data][tail padding]}
+ * -- so the unchanged {@link PackageInput} can consume it. Sub-volume CRC32s are
+ * verified as their boundaries are crossed.
+ */
+public final class VolumeSet {
+    private final byte[] masterHead;
+    private final long dataStart;
+    private final VolumeIndex index;
+    private final List<File> subVolumes;
+
+    private VolumeSet(
+        @NonNull byte[] masterHead,
+        long dataStart,
+        @NonNull VolumeIndex index,
+        @NonNull List<File> subVolumes
+    ) {
+        this.masterHead = masterHead;
+        this.dataStart = dataStart;
+        this.index = index;
+        this.subVolumes = subVolumes;
+    }
+
+    /** True when {@code path} looks like a sub-volume member ({@code ....NNN}). */
+    public static boolean isSubVolume(@NonNull String path) {
+        return path.matches(fmt(".*\\.\\d{%d}", PackageConstants.VOLUME_SUFFIX_DIGITS));
+    }
+
+    /** Maps any picked path to its metadata master: strips a {@code .NNN}
+     * sub-volume suffix, or returns the path unchanged for the master itself. */
+    @NonNull
+    public static String masterOf(@NonNull String path) {
+        if (!isSubVolume(path)) return path;
+        return path.substring(0, path.length() - PackageConstants.VOLUME_SUFFIX_DIGITS - 1);
+    }
+
+    public long dataSize() {
+        return index.dataSize;
+    }
+
+    public int count() {
+        return subVolumes.size();
+    }
+
+    /**
+     * Parses and validates the whole set from the master path. Throws with a
+     * clear message when a sub-volume is missing or a size does not match.
+     */
+    @NonNull
+    public static VolumeSet discover(@NonNull String masterPath) throws IOException {
+        var master = new File(masterPath);
+        var all = readAllBytes(master);
+        if (all.length < PackageConstants.HEADER_SIZE)
+            throw new IOException("master too small");
+        PackageHeader hdr;
+        try {
+            hdr = PackageHeader.fromBytes(Arrays.copyOf(all, PackageConstants.HEADER_SIZE));
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException("invalid master header", e);
+        }
+        if (hdr.volumeCount <= 0)
+            throw new IOException("not a multi-volume package");
+        long dataStart = alignUpStrict(alignUp(PackageConstants.HEADER_SIZE) + hdr.manifestSize);
+        if (all.length < dataStart)
+            throw new IOException("truncated master");
+        var indexJson = new String(all, (int) dataStart, all.length - (int) dataStart, UTF_8);
+        VolumeIndex index;
+        try {
+            index = new VolumeIndex(indexJson);
+        } catch (JSONException e) {
+            throw new IOException("failed to parse volume index", e);
+        }
+        if (index.volumes.size() != hdr.volumeCount)
+            throw new IOException(fmt(
+                "volume count mismatch: header %d, index %d",
+                hdr.volumeCount, index.volumes.size()
+            ));
+        var subs = new ArrayList<File>();
+        for (int i = 0; i < index.volumes.size(); i++) {
+            var entry = index.volumes.get(i);
+            var f = new File(VolumeSplitOutputStream.volumeName(masterPath, i + 1));
+            if (!f.isFile())
+                throw new IOException(fmt("missing sub-volume %d (%s)", i + 1, f.getName()));
+            if (f.length() != entry.size)
+                throw new IOException(fmt(
+                    "sub-volume %d size mismatch: on-disk %d, expected %d",
+                    i + 1, f.length(), entry.size
+                ));
+            subs.add(f);
+        }
+        var head = Arrays.copyOf(all, (int) dataStart);
+        return new VolumeSet(head, dataStart, index, subs);
+    }
+
+    /**
+     * Rebuilds the single-file byte stream: master head (header + manifest +
+     * padding) ++ concatenated sub-volume data (CRC-checked) ++ trailing
+     * alignment zeros. Feed to {@link PackageInput#open(InputStream, long)}.
+     */
+    @NonNull
+    public InputStream openLogicalStream() {
+        long dataEnd = dataStart + index.dataSize;
+        long tailPad = alignUp(dataEnd) - dataEnd;
+        var streams = new Vector<InputStream>();
+        streams.add(new ByteArrayInputStream(masterHead));
+        streams.add(new SubVolumeConcatStream());
+        streams.add(new ZeroInputStream(tailPad));
+        return new SequenceInputStream(streams.elements());
+    }
+
+    @NonNull
+    private static byte[] readAllBytes(@NonNull File f) throws IOException {
+        long len = f.length();
+        if (len <= 0 || len > (16L << 20))
+            throw new IOException(fmt("unexpected master size: %d", len));
+        var buf = new byte[(int) len];
+        try (var in = new FileInputStream(f)) {
+            int off = 0;
+            while (off < buf.length) {
+                int n = in.read(buf, off, buf.length - off);
+                if (n < 0) throw new IOException("short read on master");
+                off += n;
+            }
+        }
+        return buf;
+    }
+
+    private final class SubVolumeConcatStream extends InputStream {
+        private int idx = -1;
+        private InputStream cur;
+        private CRC32 crc;
+        private long remaining;
+
+        private boolean advance() throws IOException {
+            if (cur != null) {
+                verify();
+                cur.close();
+                cur = null;
+            }
+            idx++;
+            if (idx >= subVolumes.size()) return false;
+            cur = new BufferedInputStream(
+                new FileInputStream(subVolumes.get(idx)), PackageConstants.BUFFER
+            );
+            crc = new CRC32();
+            remaining = index.volumes.get(idx).size;
+            return true;
+        }
+
+        private void verify() throws IOException {
+            if (remaining != 0)
+                throw new IOException(fmt("sub-volume %d truncated", idx + 1));
+            if (crc.getValue() != index.volumes.get(idx).crc32)
+                throw new IOException(fmt("sub-volume %d checksum mismatch", idx + 1));
+        }
+
+        @Override
+        public int read() throws IOException {
+            var one = new byte[1];
+            int n = read(one, 0, 1);
+            return n < 0 ? -1 : (one[0] & 0xff);
+        }
+
+        @Override
+        public int read(@NonNull byte[] b, int off, int len) throws IOException {
+            while (true) {
+                if (cur == null || remaining == 0) {
+                    if (!advance()) return -1;
+                    continue;
+                }
+                int toRead = (int) Math.min(len, remaining);
+                int n = cur.read(b, off, toRead);
+                if (n < 0)
+                    throw new IOException(fmt("sub-volume %d ended early", idx + 1));
+                crc.update(b, off, n);
+                remaining -= n;
+                return n;
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (cur != null) {
+                cur.close();
+                cur = null;
+            }
+        }
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/lib/pkg/VolumeSplitOutputStream.java
+++ b/app/src/main/java/cn/classfun/droidvm/lib/pkg/VolumeSplitOutputStream.java
@@ -1,0 +1,134 @@
+package cn.classfun.droidvm.lib.pkg;
+
+import static cn.classfun.droidvm.lib.utils.StringUtils.fmt;
+
+import androidx.annotation.NonNull;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.CRC32;
+
+/**
+ * Slices the compressed data stream across fixed-size sub-volumes
+ * {@code <base>.001, <base>.002, ...}. Pure data: no header, manifest or magic
+ * -- those live in the metadata master ({@link VolumeIndex}). Tracks each
+ * sub-volume's size and CRC32. {@link #close()} is a no-op so an upstream
+ * compression stream can be closed without ending the volume set; finalize
+ * explicitly with {@link #finish()} and read {@link #entries()}/{@link #dataSize()}.
+ */
+public final class VolumeSplitOutputStream extends OutputStream {
+    private final String basePath;
+    private final long volumeSize;
+    private final List<VolumeIndex.Entry> entries = new ArrayList<>();
+    private final List<File> files = new ArrayList<>();
+    private OutputStream current;
+    private CRC32 currentCrc;
+    private long currentBytes;
+    private int index;
+    private long position;
+    private boolean finished;
+
+    public VolumeSplitOutputStream(@NonNull String basePath, long volumeSize) {
+        this.basePath = basePath;
+        this.volumeSize = volumeSize;
+    }
+
+    @NonNull
+    public static String volumeName(@NonNull String basePath, int index) {
+        return fmt("%s.%0" + PackageConstants.VOLUME_SUFFIX_DIGITS + "d", basePath, index); // concat-ok
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        write(new byte[]{(byte) b}, 0, 1);
+    }
+
+    @Override
+    public void write(@NonNull byte[] b, int off, int len) throws IOException {
+        if (finished) throw new IOException("volume stream already finished");
+        while (len > 0) {
+            if (current == null || currentBytes >= volumeSize) rollVolume();
+            int chunk = (int) Math.min(len, volumeSize - currentBytes);
+            current.write(b, off, chunk);
+            currentCrc.update(b, off, chunk);
+            currentBytes += chunk;
+            position += chunk;
+            off += chunk;
+            len -= chunk;
+        }
+    }
+
+    private void rollVolume() throws IOException {
+        if (current != null) closeCurrent();
+        index++;
+        if (index > PackageConstants.VOLUME_MAX_COUNT)
+            throw new IOException(fmt(
+                "too many volumes (> %d); use a larger volume size",
+                PackageConstants.VOLUME_MAX_COUNT
+            ));
+        var file = new File(volumeName(basePath, index));
+        files.add(file);
+        current = new BufferedOutputStream(new FileOutputStream(file), PackageConstants.BUFFER);
+        currentCrc = new CRC32();
+        currentBytes = 0;
+    }
+
+    private void closeCurrent() throws IOException {
+        entries.add(new VolumeIndex.Entry(index, currentBytes, currentCrc.getValue()));
+        current.flush();
+        current.close();
+        current = null;
+    }
+
+    /** Closes the final sub-volume and records its entry. */
+    public void finish() throws IOException {
+        if (finished) return;
+        if (current != null) closeCurrent();
+        finished = true;
+    }
+
+    /** Total bytes written across all sub-volumes (the compressed data size). */
+    public long dataSize() {
+        return position;
+    }
+
+    public int currentIndex() {
+        return index;
+    }
+
+    public int volumeCount() {
+        return entries.size();
+    }
+
+    @NonNull
+    public List<VolumeIndex.Entry> entries() {
+        return entries;
+    }
+
+    @NonNull
+    public List<File> files() {
+        return files;
+    }
+
+    /** No-op: mirrors RandomAccessFileOutputStream so upstream close() cannot
+     * end the volume set prematurely. Use {@link #finish()} to finalize. */
+    @Override
+    public void close() {
+    }
+
+    /** Closes any open sub-volume without recording it, for error cleanup. */
+    public void abort() {
+        if (current != null) {
+            try {
+                current.close();
+            } catch (IOException ignored) {
+            }
+            current = null;
+        }
+    }
+}

--- a/app/src/main/java/cn/classfun/droidvm/lib/utils/BinaryUtils.java
+++ b/app/src/main/java/cn/classfun/droidvm/lib/utils/BinaryUtils.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.charset.CodingErrorAction;
@@ -41,6 +42,15 @@ public class BinaryUtils {
         while (rem > 0) {
             int n = (int) Math.min(ZERO.length, rem);
             raf.write(ZERO, 0, n);
+            rem -= n;
+        }
+    }
+
+    public static void writeZero(@NonNull OutputStream out, long count) throws IOException {
+        long rem = count;
+        while (rem > 0) {
+            int n = (int) Math.min(ZERO.length, rem);
+            out.write(ZERO, 0, n);
             rem -= n;
         }
     }

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/pkg/exports/VMPkgExportActivity.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/pkg/exports/VMPkgExportActivity.java
@@ -54,6 +54,7 @@ import cn.classfun.droidvm.lib.store.vm.VMStore;
 import cn.classfun.droidvm.lib.utils.ShareUtils;
 import cn.classfun.droidvm.ui.widgets.container.CollapsibleContainer;
 import cn.classfun.droidvm.ui.widgets.row.ChooseRowWidget;
+import cn.classfun.droidvm.ui.widgets.row.TextInputRowWidget;
 
 public final class VMPkgExportActivity extends AppCompatActivity
     implements DaemonConnection.EventListener {
@@ -70,6 +71,7 @@ public final class VMPkgExportActivity extends AppCompatActivity
     private TextView tvDiskSummary;
     private ChooseRowWidget chooseCompression;
     private TextView tvCompressionDesc;
+    private TextInputRowWidget inputVolumeSize;
     private LinearProgressIndicator pbRun;
     private TextView tvStatus;
     private TextView tvFileName;
@@ -78,9 +80,11 @@ public final class VMPkgExportActivity extends AppCompatActivity
     private ExtendedFloatingActionButton fabShare;
     private VMConfig config;
     private Compression compression = PackageConstants.DEFAULT_COMPRESSION;
+    private long volumeSize = 0;
     private VMPkgExportDiskAdapter adapter;
     private String pendingTaskId = null;
     private String path = null;
+    private int exportVolumeIndex = 0;
     private boolean exporting = false;
     private Phase phase = Phase.IDLE;
     private final ActivityResultLauncher<String> createDocLauncher =
@@ -108,6 +112,7 @@ public final class VMPkgExportActivity extends AppCompatActivity
         tvDiskSummary = findViewById(R.id.tv_disk_summary);
         chooseCompression = findViewById(R.id.choose_compression);
         tvCompressionDesc = findViewById(R.id.tv_compression_desc);
+        inputVolumeSize = findViewById(R.id.input_volume_size);
         pbRun = findViewById(R.id.pb_run);
         tvStatus = findViewById(R.id.tv_status);
         tvFileName = findViewById(R.id.tv_filename);
@@ -144,6 +149,9 @@ public final class VMPkgExportActivity extends AppCompatActivity
         containerDisks.setAdapter(adapter);
         bindDisks();
         bindCompression();
+        // Volume split defaults off: leave the input empty so export produces a
+        // single self-contained file unless the user enters a size.
+        inputVolumeSize.setText("");
         var handler = new VMPkgExportOnBackPressedCallback();
         toolbar.setNavigationOnClickListener(v -> handler.handleOnBackPressed());
         getOnBackPressedDispatcher().addCallback(this, handler);
@@ -303,6 +311,23 @@ public final class VMPkgExportActivity extends AppCompatActivity
 
     private void onDocPicked(@Nullable Uri uri) {
         if (uri == null || exporting) return;
+        // Clear any stale volume index from a previous export so a following
+        // single-file export does not inherit its "volume N" status.
+        exportVolumeIndex = 0;
+        // Read the (empty = single file) volume size on the UI thread before
+        // handing off to the worker pool.
+        var vsText = inputVolumeSize.getText().trim();
+        if (vsText.isEmpty()) {
+            volumeSize = 0;
+        } else if (!inputVolumeSize.isInputValid()) {
+            showToast(R.string.vmpkg_export_failed, getString(
+                R.string.vmpkg_export_volume_size_invalid,
+                PackageConstants.MIN_VOLUME_SIZE / (1024 * 1024)
+            ));
+            return;
+        } else {
+            volumeSize = inputVolumeSize.getValue();
+        }
         runOnPool(() -> startExport(uri));
     }
 
@@ -344,6 +369,7 @@ public final class VMPkgExportActivity extends AppCompatActivity
             .put("disks", diskIndices)
             .put("dest_path", destPath)
             .put("compression", compression)
+            .put("volume_size", volumeSize)
             .onResponse(onExport)
             .onUnsuccessful(f)
             .onError(err)
@@ -384,6 +410,7 @@ public final class VMPkgExportActivity extends AppCompatActivity
         var bytesTotal = data.optLong("bytes_total");
         var file = data.optString("file");
         var message = data.optString("message");
+        exportVolumeIndex = data.optInt("volume_index", exportVolumeIndex);
         mainHandler.post(() -> onProgress(
             phase, done, total, bytesDone, bytesTotal, file, message
         ));
@@ -424,7 +451,10 @@ public final class VMPkgExportActivity extends AppCompatActivity
                 applyProgress(done, total, bytesDone, bytesTotal);
                 break;
             case PACK:
-                tvStatus.setText(R.string.vmpkg_export_pack);
+                if (exportVolumeIndex > 0) tvStatus.setText(getString(
+                    R.string.vmpkg_export_pack_volume, exportVolumeIndex
+                ));
+                else tvStatus.setText(R.string.vmpkg_export_pack);
                 applyProgress(done, total, bytesDone, bytesTotal);
                 applyProgressDetail(file, bytesDone, bytesTotal);
                 break;
@@ -471,6 +501,7 @@ public final class VMPkgExportActivity extends AppCompatActivity
         pbRun.setVisibility(exporting ? VISIBLE : GONE);
         pbRun.setIndeterminate(exporting);
         chooseCompression.setEnabled(!exporting);
+        inputVolumeSize.setEnabled(!exporting);
         containerDisks.setEnabled(!exporting);
         adapter.setEnabled(!exporting);
     }

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/pkg/imports/VMPkgImportActivity.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/pkg/imports/VMPkgImportActivity.java
@@ -41,6 +41,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.util.Date;
@@ -51,6 +52,7 @@ import cn.classfun.droidvm.lib.pkg.PackageConstants;
 import cn.classfun.droidvm.lib.pkg.PackageInput;
 import cn.classfun.droidvm.lib.pkg.PackageManifest;
 import cn.classfun.droidvm.lib.pkg.Phase;
+import cn.classfun.droidvm.lib.pkg.VolumeSet;
 import cn.classfun.droidvm.lib.store.disk.DiskConfig;
 import cn.classfun.droidvm.lib.store.disk.DiskStore;
 import cn.classfun.droidvm.lib.store.network.NetworkConfig;
@@ -86,10 +88,14 @@ public final class VMPkgImportActivity extends AppCompatActivity
     private TextView tvProgressDetail;
     private View groupSummary;
     private Uri pickedUri;
+    // Real filesystem path of the metadata master, resolved at pick time when a
+    // sub-volume (.NNN) is chosen so preview/import target the master directly.
+    private String masterRealPath;
     private PackageManifest preview;
     private VMPkgImportDiskAdapter diskAdapter;
     private VMPkgImportNetworkAdapter networkAdapter;
     private String pendingTaskId = null;
+    private int importVolumeTotal = 0;
     private boolean importing = false;
     private NetworkImportMode networkMode = NetworkImportMode.AUTO;
     private final ActivityResultLauncher<String[]> openDocLauncher =
@@ -188,21 +194,40 @@ public final class VMPkgImportActivity extends AppCompatActivity
     private void onDocPicked(@Nullable Uri uri) {
         if (uri == null || importing) return;
         pickedUri = uri;
+        masterRealPath = null;
+        importVolumeTotal = 0;
         tvError.setVisibility(GONE);
         groupSummary.setVisibility(GONE);
         btnImport.setEnabled(false);
         tvStatus.setText(R.string.vmpkg_import_reading);
         runOnPool(() -> {
-            try (var is = getContentResolver().openInputStream(uri)) {
-                if (is == null) throw new RuntimeException("Cannot open file");
-                try (var input = PackageInput.open(is)) {
-                    preview = input.manifest;
-                }
+            try {
+                preview = readPreviewManifest(uri);
                 mainHandler.post(this::showPreview);
             } catch (Exception e) {
                 mainHandler.post(() -> showError(getString(R.string.vmpkg_import_invalid, e.getMessage())));
             }
         });
+    }
+
+    @NonNull
+    private PackageManifest readPreviewManifest(@NonNull Uri uri) throws Exception {
+        // A picked sub-volume (.NNN) has no header/manifest; redirect to its
+        // metadata master in the same folder (needs MANAGE_EXTERNAL_STORAGE).
+        var real = resolveUriPath(this, uri);
+        if (real != null && !real.isEmpty() && VolumeSet.isSubVolume(real)) {
+            masterRealPath = VolumeSet.masterOf(real);
+            try (var is = new FileInputStream(masterRealPath)) {
+                return PackageInput.peekManifest(is);
+            }
+        }
+        // Master or single file: SAF stream is enough. Remember the resolved
+        // master path (may be null) so import can reuse it.
+        masterRealPath = real == null || real.isEmpty() ? null : VolumeSet.masterOf(real);
+        try (var is = getContentResolver().openInputStream(uri)) {
+            if (is == null) throw new RuntimeException("Cannot open file");
+            return PackageInput.peekManifest(is);
+        }
     }
 
     @SuppressLint("NotifyDataSetChanged")
@@ -252,7 +277,10 @@ public final class VMPkgImportActivity extends AppCompatActivity
 
     private void doImport() {
         if (pickedUri == null || preview == null || importing) return;
-        var srcPath = resolveUriPath(this, pickedUri);
+        // Prefer the master path resolved at pick time; the daemon maps any
+        // .NNN sub-volume to its master anyway.
+        var srcPath = masterRealPath;
+        if (srcPath == null || srcPath.isEmpty()) srcPath = resolveUriPath(this, pickedUri);
         if (srcPath == null || srcPath.isEmpty()) {
             showError(getString(
                 R.string.vmpkg_import_failed,
@@ -296,6 +324,7 @@ public final class VMPkgImportActivity extends AppCompatActivity
         var phase = optEnum(data, "phase", Phase.SCAN);
         var done = data.optInt("done", 0);
         var total = data.optInt("total", 0);
+        importVolumeTotal = data.optInt("volume_total", importVolumeTotal);
         var file = data.optString("file", "");
         var bytesDone = data.optLong("bytes_done", -1);
         var bytesTotal = data.optLong("bytes_total", -1);
@@ -332,7 +361,10 @@ public final class VMPkgImportActivity extends AppCompatActivity
     ) {
         switch (phase) {
             case PACK:
-                tvStatus.setText(R.string.vmpkg_import_running);
+                if (importVolumeTotal > 0) tvStatus.setText(getString(
+                    R.string.vmpkg_import_running_volume, importVolumeTotal
+                ));
+                else tvStatus.setText(R.string.vmpkg_import_running);
                 applyProgress(done, total, bytesDone, bytesTotal);
                 applyProgressDetail(file, bytesDone, bytesTotal);
                 break;

--- a/app/src/main/res/layout/activity_vmpkg_export.xml
+++ b/app/src/main/res/layout/activity_vmpkg_export.xml
@@ -153,6 +153,27 @@
                     android:textAppearance="?attr/textAppearanceBodySmall"
                     android:textColor="?android:attr/textColorSecondary" />
 
+                <cn.classfun.droidvm.ui.widgets.row.TextInputRowWidget
+                    android:id="@+id/input_volume_size"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/vmpkg_export_volume_size_hint"
+                    android:icon="@drawable/ic_sd"
+                    app:ti_max="1TiB"
+                    app:ti_min="16MiB"
+                    app:ti_mode="size" />
+
+                <TextView
+                    android:id="@+id/tv_volume_desc"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginEnd="16dp"
+                    android:layout_marginBottom="12dp"
+                    android:text="@string/vmpkg_export_volume_size_desc"
+                    android:textAppearance="?attr/textAppearanceBodySmall"
+                    android:textColor="?android:attr/textColorSecondary" />
+
             </cn.classfun.droidvm.ui.widgets.container.CollapsibleContainer>
 
             <com.google.android.material.progressindicator.LinearProgressIndicator

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1056,6 +1056,11 @@
     <string name="vmpkg_export_scan">正在扫描磁盘\u2026</string>
     <string name="vmpkg_export_pack">正在打包磁盘\u2026</string>
     <string name="vmpkg_export_progress_detail">%1$s / %2$s %3$d%%</string>
+    <string name="vmpkg_export_volume_size_hint">分卷大小</string>
+    <string name="vmpkg_export_volume_size_desc">将包拆分为固定大小的分卷（.001、.002…）。留空则导出为单个文件。</string>
+    <string name="vmpkg_export_volume_size_invalid">分卷大小不能小于 %1$d MB</string>
+    <string name="vmpkg_export_pack_volume">正在打包磁盘（分卷 %1$d）…</string>
+    <string name="vmpkg_import_running_volume">正在导入（共 %1$d 卷）…</string>
     <string name="vmpkg_export_success">包已创建</string>
     <string name="vmpkg_export_success_path">包已创建：%1$s</string>
     <string name="vmpkg_export_failed">导出失败：%1$s</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1056,6 +1056,11 @@
     <string name="vmpkg_export_scan">正在掃描磁碟\u2026</string>
     <string name="vmpkg_export_pack">正在打包磁碟\u2026</string>
     <string name="vmpkg_export_progress_detail">%1$s / %2$s %3$d%%</string>
+    <string name="vmpkg_export_volume_size_hint">分卷大小</string>
+    <string name="vmpkg_export_volume_size_desc">將封裝包拆分為固定大小的分卷（.001、.002…）。留空則匯出為單一檔案。</string>
+    <string name="vmpkg_export_volume_size_invalid">分卷大小不能小於 %1$d MB</string>
+    <string name="vmpkg_export_pack_volume">正在打包磁碟（分卷 %1$d）…</string>
+    <string name="vmpkg_import_running_volume">正在匯入（共 %1$d 卷）…</string>
     <string name="vmpkg_export_success">包已建立</string>
     <string name="vmpkg_export_success_path">包已建立：%1$s</string>
     <string name="vmpkg_export_failed">匯出失敗：%1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1089,9 +1089,13 @@
     <string name="vmpkg_export_compression_gzip_desc">Gzip is fast with low CPU usage but produces larger archives.</string>
     <string name="vmpkg_export_compression_xz_desc">XZ (LZMA2) is slowest and CPU-heavy but produces the smallest archives.</string>
     <string name="vmpkg_export_compression_zstd_desc">Zstandard offers the best balance: fast compression with good ratios.</string>
+    <string name="vmpkg_export_volume_size_hint">Volume size</string>
+    <string name="vmpkg_export_volume_size_desc">Split the package into fixed-size volumes (.001, .002, \u2026). Leave empty for a single file.</string>
+    <string name="vmpkg_export_volume_size_invalid">Volume size must be at least %1$d MB</string>
     <string name="vmpkg_export_running">Submitting to daemon\u2026</string>
     <string name="vmpkg_export_scan">Scanning disks\u2026</string>
     <string name="vmpkg_export_pack">Packaging disks\u2026</string>
+    <string name="vmpkg_export_pack_volume">Packaging disks (volume %1$d)\u2026</string>
     <string name="vmpkg_export_progress_detail">%1$s / %2$s %3$d%%</string>
     <string name="vmpkg_export_success">Package created</string>
     <string name="vmpkg_export_success_path">Package created: %1$s</string>
@@ -1110,6 +1114,7 @@
     <string name="vmpkg_import_do">Import</string>
     <string name="vmpkg_import_reading">Reading package\u2026</string>
     <string name="vmpkg_import_running">Importing\u2026</string>
+    <string name="vmpkg_import_running_volume">Importing (%1$d volumes)\u2026</string>
     <string name="vmpkg_import_disks">Disks</string>
     <string name="vmpkg_import_networks">Networks</string>
     <string name="vmpkg_import_no_disks">No disks in this package.</string>


### PR DESCRIPTION
- split compressed stream into fixed-size .001/.002 sub-volumes with a metadata master holding header + manifest + volume index
- verify sub-volume size and CRC32 on import and rebuild the logical byte stream
- add volume_size input to export UI, default off (single file)
- clean up partial and stale sub-volumes on export failure/re-run
- reset volume status fields between operations to avoid stale UI