### PR TITLE
Constrain pflash usage in vm properties.

### DIFF
--- a/app/src/main/java/cn/classfun/droidvm/daemon/vm/BootPlan.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/vm/BootPlan.java
@@ -60,6 +60,11 @@ public final class BootPlan {
     /** Custom UEFI firmware path; empty = builtin (QEMU honors, crosvm ignores). */
     @NonNull
     public final String firmware;
+    /** Custom UEFI vars path; empty = builtin EDK2 vars. */
+    @NonNull
+    public final String vars;
+    /** Whether the UEFI vars pflash is attached. */
+    public final boolean varsEnabled;
     @NonNull
     public final String kernel;
     @NonNull
@@ -73,12 +78,14 @@ public final class BootPlan {
     public final boolean entryFallback;
 
     private BootPlan(
-        boolean uefi, @NonNull String firmware, @NonNull String kernel,
-        @NonNull String initrd, @NonNull String cmdline,
-        @Nullable String entryTitle, boolean entryFallback
+        boolean uefi, @NonNull String firmware, @NonNull String vars,
+        boolean varsEnabled, @NonNull String kernel, @NonNull String initrd,
+        @NonNull String cmdline, @Nullable String entryTitle, boolean entryFallback
     ) {
         this.uefi = uefi;
         this.firmware = firmware;
+        this.vars = vars;
+        this.varsEnabled = varsEnabled;
         this.kernel = kernel;
         this.initrd = initrd;
         this.cmdline = cmdline;
@@ -116,14 +123,18 @@ public final class BootPlan {
         if (BootConfig.BUILTIN_ENTRY_KEY.equals(entryOverrideId))
             return resolveBuiltin(config, boot);
         if (boot.getProtocol() == BootConfig.Protocol.UEFI)
-            return new BootPlan(true, boot.getUefiFirmware(), "", "", "", null, false);
+            return new BootPlan(
+                true, boot.getUefiFirmware(), boot.getUefiVars(),
+                boot.isUefiVarsEnabled(), "", "", "", null, false
+            );
         if (boot.getLinuxSource() == BootConfig.LinuxSource.MANUAL) {
             var kernel = boot.getKernel();
             // pre-boot{} configs stored the EDK2 path as the kernel
             if (kernel.equals(PATH_EDK2_FIRMWARE))
-                return new BootPlan(true, "", "", "", "", null, false);
+                return new BootPlan(true, "", "", false, "", "", "", null, false);
             return new BootPlan(
-                false, "", kernel, boot.getInitrd(), boot.getCmdline(), null, false
+                false, "", "", false, kernel, boot.getInitrd(),
+                boot.getCmdline(), null, false
             );
         }
         return resolveImage(config, boot, entryOverrideId);
@@ -142,7 +153,7 @@ public final class BootPlan {
     private static BootPlan resolveBuiltin(
         @NonNull VMConfig config, @NonNull BootConfig boot) {
         return new BootPlan(
-            false, "", PATH_BUILTIN_KERNEL, PATH_BUILTIN_INITRD,
+            false, "", "", false, PATH_BUILTIN_KERNEL, PATH_BUILTIN_INITRD,
             builtinCmdline(config, boot), "DroidVM built-in kernel", false
         );
     }
@@ -214,7 +225,7 @@ public final class BootPlan {
         var initrd = new File(cacheDir, "initrd");
         var title = optStr(entry, "title");
         return new BootPlan(
-            false, "",
+            false, "", "", false,
             new File(cacheDir, "kernel").getAbsolutePath(),
             initrd.exists() ? initrd.getAbsolutePath() : "",
             cmdline,

--- a/app/src/main/java/cn/classfun/droidvm/daemon/vm/backend/CrosvmBackendInstance.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/vm/backend/CrosvmBackendInstance.java
@@ -4,6 +4,7 @@ import static android.net.LocalSocketAddress.Namespace.FILESYSTEM;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static cn.classfun.droidvm.lib.Constants.DATA_DIR;
 import static cn.classfun.droidvm.lib.Constants.PATH_EDK2_FIRMWARE;
+import static cn.classfun.droidvm.lib.Constants.PATH_EDK2_VARS;
 import static cn.classfun.droidvm.lib.store.enums.Enums.optEnum;
 import static cn.classfun.droidvm.lib.store.vm.DisplayBackend.SIMPLEFB;
 import static cn.classfun.droidvm.lib.store.vm.DisplayBackend.VIRTIO_GPU;
@@ -230,10 +231,22 @@ public final class CrosvmBackendInstance extends VMBackendInstance {
         if (boot.uefi) {
             // crosvm has no custom-firmware support; always builtin EDK2
             args.add(PATH_EDK2_FIRMWARE);
+            if (boot.varsEnabled) {
+                var vars = boot.vars.isEmpty() ? PATH_EDK2_VARS : boot.vars;
+                args.add("--pflash");
+                args.add(fmt("path=%s,block_size=%d", vars, pflashBlockSize(vars)));
+            }
         } else if (!boot.kernel.isEmpty()) {
             args.add(boot.kernel);
         }
         return args;
+    }
+
+    private static long pflashBlockSize(@NonNull String path) {
+        long size = new File(path).length();
+        for (long blockSize : new long[]{262144, 65536, 4096})
+            if (size > 0 && size % blockSize == 0) return blockSize;
+        return 262144;
     }
 
     private void buildDiskCommand(@NonNull List<String> args) {
@@ -257,10 +270,6 @@ public final class CrosvmBackendInstance extends VMBackendInstance {
                 case PMEM:
                     if (readonly) arg.append(",ro=true");
                     args.add("--pmem");
-                    args.add(arg.toString());
-                    break;
-                case PFLASH:
-                    args.add("--pflash");
                     args.add(arg.toString());
                     break;
                 case CDROM:

--- a/app/src/main/java/cn/classfun/droidvm/daemon/vm/backend/QemuBackendInstance.java
+++ b/app/src/main/java/cn/classfun/droidvm/daemon/vm/backend/QemuBackendInstance.java
@@ -4,6 +4,7 @@ import static android.net.LocalSocketAddress.Namespace.FILESYSTEM;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static cn.classfun.droidvm.lib.Constants.DATA_DIR;
 import static cn.classfun.droidvm.lib.Constants.PATH_EDK2_QEMU_FIRMWARE;
+import static cn.classfun.droidvm.lib.Constants.PATH_EDK2_VARS;
 import static cn.classfun.droidvm.lib.store.enums.Enums.optEnum;
 import static cn.classfun.droidvm.lib.utils.AssetUtils.getPrebuiltBinaryPath;
 import static cn.classfun.droidvm.lib.utils.FileUtils.deleteFile;
@@ -190,6 +191,11 @@ public final class QemuBackendInstance extends VMBackendInstance {
         if (boot.uefi) {
             args.add("-bios");
             args.add(boot.firmware.isEmpty() ? PATH_EDK2_QEMU_FIRMWARE : boot.firmware);
+            if (boot.varsEnabled) {
+                var vars = boot.vars.isEmpty() ? PATH_EDK2_VARS : boot.vars;
+                args.add("-drive");
+                args.add(fmt("file=%s,if=pflash,format=raw", vars));
+            }
         }
         if (!boot.kernel.isEmpty()) {
             args.add("-kernel");

--- a/app/src/main/java/cn/classfun/droidvm/lib/Constants.java
+++ b/app/src/main/java/cn/classfun/droidvm/lib/Constants.java
@@ -18,6 +18,9 @@ public final class Constants {
     public static final String PATH_BUILTIN_INITRD = pathJoin(DATA_DIR, "/usr/share/droidvm/initramfs.img");
     public static final String PATH_EDK2_FIRMWARE = pathJoin(DATA_DIR, "/usr/share/droidvm/edk2-gunyah.fd");
     public static final String PATH_EDK2_QEMU_FIRMWARE = pathJoin(DATA_DIR, "/usr/share/droidvm/edk2-qemu.fd");
+    public static final String PATH_EDK2_VARS = pathJoin(DATA_DIR, "/usr/share/droidvm/edk2-gunyah.vars.fd");
+    /** crosvm arm64 pflash window: AARCH64_PLATFORM_MMIO_SIZE (8 MiB). */
+    public static final long PFLASH_MAX_SIZE = 8L * 1024 * 1024;
     public static final String GITHUB_ISSUE_URL = "https://github.com/Droid-VM/DroidVM/issues";
     // droidvm + daemon are CMake-built and shipped as APK assets. The
     // third-party daemons (gvswitch/pbridge/bridgedhcp/netbox) and lbx now

--- a/app/src/main/java/cn/classfun/droidvm/lib/store/vm/BootConfig.java
+++ b/app/src/main/java/cn/classfun/droidvm/lib/store/vm/BootConfig.java
@@ -17,7 +17,7 @@ import cn.classfun.droidvm.lib.store.enums.StringEnum;
  * <pre>
  * boot: {
  *   protocol: "uefi" | "linux",
- *   uefi:  { firmware },                       // empty = builtin EDK2
+ *   uefi:  { firmware, vars },                 // empty = builtin EDK2
  *   linux: {
  *     source: "manual" | "image",
  *     kernel, initrd, cmdline,                 // manual-source fields
@@ -134,6 +134,25 @@ public final class BootConfig {
 
     public void setUefiFirmware(@NonNull String firmware) {
         uefi().set("firmware", firmware);
+    }
+
+    /** Custom UEFI vars path; empty = builtin EDK2 vars. */
+    @NonNull
+    public String getUefiVars() {
+        return uefi().optString("vars", "");
+    }
+
+    public void setUefiVars(@NonNull String vars) {
+        uefi().set("vars", vars);
+    }
+
+    /** Whether the UEFI vars pflash is attached; off = no pflash. */
+    public boolean isUefiVarsEnabled() {
+        return uefi().optBoolean("vars_enabled", true);
+    }
+
+    public void setUefiVarsEnabled(boolean enabled) {
+        uefi().set("vars_enabled", enabled);
     }
 
     // --- linux branch ---

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/edit/basic/VMEditBasicTab.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/edit/basic/VMEditBasicTab.java
@@ -241,4 +241,11 @@ public final class VMEditBasicTab extends VMEditBaseTab {
     public ProtectedVM getCurrentProtectedVm() {
         return chooseProtectedVm.getSelectedItem();
     }
+
+    /** The backend as currently selected */
+    @NonNull
+    public VMBackend getCurrentBackend() {
+        var backend = chooseBackend.<VMBackend>getSelectedItem();
+        return backend == null ? VMBackend.DEFAULT : backend;
+    }
 }

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/edit/boot/VMEditBootTab.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/edit/boot/VMEditBootTab.java
@@ -2,6 +2,7 @@ package cn.classfun.droidvm.ui.vm.edit.boot;
 
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
+import static cn.classfun.droidvm.lib.Constants.PFLASH_MAX_SIZE;
 import static cn.classfun.droidvm.lib.Constants.PATH_BUILTIN_INITRD;
 import static cn.classfun.droidvm.lib.Constants.PATH_BUILTIN_KERNEL;
 import static cn.classfun.droidvm.lib.Constants.PATH_MICRODROID_INITRD;
@@ -31,6 +32,7 @@ import com.google.android.material.color.MaterialColors;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.materialswitch.MaterialSwitch;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.regex.Pattern;
 
@@ -38,6 +40,7 @@ import cn.classfun.droidvm.R;
 import cn.classfun.droidvm.lib.store.base.DataItem;
 import cn.classfun.droidvm.lib.store.vm.BootConfig;
 import cn.classfun.droidvm.lib.store.vm.ProtectedVM;
+import cn.classfun.droidvm.lib.store.vm.VMBackend;
 import cn.classfun.droidvm.lib.store.vm.VMConfig;
 import cn.classfun.droidvm.lib.store.vm.VMStore;
 import cn.classfun.droidvm.lib.ui.CopyableField;
@@ -63,6 +66,8 @@ public final class VMEditBootTab extends VMEditBaseTab {
     private DropdownRowWidget ddProtocol;
     private CollapsibleContainer containerUefi;
     private TextInputRowWidget inputUefiFirmware;
+    private SwitchRowWidget swUefiVarsEnabled;
+    private TextInputRowWidget inputUefiVars;
     private CollapsibleContainer containerKernel;
     private DropdownRowWidget ddSource;
     private View layoutImage;
@@ -105,6 +110,8 @@ public final class VMEditBootTab extends VMEditBaseTab {
         ddProtocol = view.findViewById(R.id.dd_boot_protocol);
         containerUefi = view.findViewById(R.id.container_uefi);
         inputUefiFirmware = view.findViewById(R.id.input_uefi_firmware);
+        swUefiVarsEnabled = view.findViewById(R.id.sw_uefi_vars_enabled);
+        inputUefiVars = view.findViewById(R.id.input_uefi_vars);
         containerKernel = view.findViewById(R.id.container_kernel);
         ddSource = view.findViewById(R.id.dd_kernel_source);
         layoutImage = view.findViewById(R.id.layout_kernel_image);
@@ -157,6 +164,11 @@ public final class VMEditBootTab extends VMEditBaseTab {
             if (isImageMode() && scanned == null) rescan();
         });
         inputUefiFirmware.setIconButtonOnClickListener(this::showFirmwareBrowseDialog);
+        inputUefiVars.setIconButtonOnClickListener(this::showVarsBrowseDialog);
+        swUefiVarsEnabled.setOnCheckedChangeListener((btn, checked) -> {
+            inputUefiVars.setVisibility(checked ? VISIBLE : GONE);
+            refreshStoragePflash();
+        });
         inputKernel.setIconButtonOnClickListener(this::showKernelBrowseDialog);
         inputInitrd.setIconButtonOnClickListener(this::showInitrdBrowseDialog);
         btnRescan.setOnClickListener(v -> rescan());
@@ -192,6 +204,30 @@ public final class VMEditBootTab extends VMEditBaseTab {
             && source == BootConfig.LinuxSource.IMAGE;
     }
 
+    /** Live value of the UEFI vars (pflash) enable switch. */
+    public boolean isVarsEnabledLive() {
+        return protocol == BootConfig.Protocol.UEFI
+            && swUefiVarsEnabled != null && swUefiVarsEnabled.isChecked();
+    }
+
+    /** Re-render the storage tab's disk list so PFLASH availability updates. */
+    private void refreshStoragePflash() {
+        try {
+            var storage = (VMEditStorageTab) parent.getTab(VMEditTab.TAB_STORAGE);
+            if (storage != null) storage.refreshDisks();
+        } catch (Exception ignored) {
+        }
+    }
+    /** The backend as currently selected in the basic tab (before save). */
+    @NonNull
+    private VMBackend currentBackend() {
+        try {
+            var basic = (VMEditBasicTab) parent.getTab(VMEditTab.TAB_BASIC);
+            if (basic != null) return basic.getCurrentBackend();
+        } catch (Exception ignored) {
+        }
+        return VMBackend.DEFAULT;
+    }
     private void applyVisibility() {
         boolean uefi = protocol == BootConfig.Protocol.UEFI;
         containerUefi.setVisibility(uefi ? VISIBLE : GONE);
@@ -199,6 +235,9 @@ public final class VMEditBootTab extends VMEditBaseTab {
         boolean image = source == BootConfig.LinuxSource.IMAGE;
         layoutImage.setVisibility(image ? VISIBLE : GONE);
         layoutManual.setVisibility(image ? GONE : VISIBLE);
+        if (uefi) {
+            inputUefiVars.setVisibility(isVarsEnabledLive() ? VISIBLE : GONE);
+        }
     }
 
     @Override
@@ -210,6 +249,8 @@ public final class VMEditBootTab extends VMEditBaseTab {
         ddProtocol.setText(protocol.getDisplayString(parent));
         ddSource.setText(source.getDisplayString(parent));
         inputUefiFirmware.setTextAndMoveCursor(boot.getUefiFirmware());
+        swUefiVarsEnabled.setChecked(boot.isUefiVarsEnabled());
+        inputUefiVars.setTextAndMoveCursor(boot.getUefiVars());
         inputKernel.setTextAndMoveCursor(boot.getKernel());
         inputInitrd.setTextAndMoveCursor(boot.getInitrd());
         bootDiskIndex = boot.getImageDisk();
@@ -233,6 +274,21 @@ public final class VMEditBootTab extends VMEditBaseTab {
             if (!firmware.isEmpty() && !checkFilePath(firmware, true)) {
                 inputUefiFirmware.setError(parent.getString(R.string.create_vm_error_path_invalid));
                 return false;
+            }
+            var vars = inputUefiVars.getText();
+            inputUefiVars.setError(null);
+            if (isVarsEnabledLive() && !vars.isEmpty()) {
+                if (!checkFilePath(vars, true)) {
+                    inputUefiVars.setError(parent.getString(R.string.create_vm_error_path_invalid));
+                    return false;
+                }
+                // crosvm-only pflash size limit
+                if (currentBackend() == VMBackend.CROSVM
+                    && new File(vars).length() > PFLASH_MAX_SIZE) {
+                    inputUefiVars.setError(parent.getString(
+                        R.string.edit_vm_uefi_vars_too_large, PFLASH_MAX_SIZE / (1024 * 1024)));
+                    return false;
+                }
             }
             return true;
         }
@@ -271,6 +327,8 @@ public final class VMEditBootTab extends VMEditBaseTab {
         var boot = BootConfig.of(config);
         boot.setProtocol(protocol);
         boot.setUefiFirmware(inputUefiFirmware.getText());
+        boot.setUefiVarsEnabled(isVarsEnabledLive());
+        boot.setUefiVars(inputUefiVars.getText());
         boot.setLinuxSource(source);
         boot.setKernel(inputKernel.getText());
         boot.setInitrd(inputInitrd.getText());
@@ -583,6 +641,29 @@ public final class VMEditBootTab extends VMEditBaseTab {
         MenuDialogBuilder.showSimple(
             parent,
             R.string.edit_vm_uefi_firmware_browse_title,
+            R.menu.menu_vm_firmware_browse,
+            listener
+        );
+    }
+
+    private void showVarsBrowseDialog() {
+        MenuItem.OnMenuItemClickListener listener = item -> {
+            var id = item.getItemId();
+            if (id == R.id.menu_firmware_builtin) {
+                inputUefiVars.setText("");
+            } else if (id == R.id.menu_firmware_external) {
+                parent.currentPicker = uri -> {
+                    if (uri != null)
+                        inputUefiVars.setTextAndMoveCursor(resolveUriPath(parent, uri));
+                    parent.currentPicker = null;
+                };
+                parent.filePickerLauncher.launch(new String[]{"*/*"});
+            }
+            return true;
+        };
+        MenuDialogBuilder.showSimple(
+            parent,
+            R.string.edit_vm_uefi_vars_browse_title,
             R.menu.menu_vm_firmware_browse,
             listener
         );

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/edit/storage/VMEditStorageTab.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/edit/storage/VMEditStorageTab.java
@@ -1,6 +1,7 @@
 package cn.classfun.droidvm.ui.vm.edit.storage;
 
 import static android.app.Activity.RESULT_OK;
+import static cn.classfun.droidvm.lib.Constants.PFLASH_MAX_SIZE;
 import static cn.classfun.droidvm.lib.utils.FileUtils.checkFileName;
 import static cn.classfun.droidvm.lib.utils.FileUtils.checkFilePath;
 import static cn.classfun.droidvm.lib.utils.StringUtils.resolveUriPath;
@@ -14,15 +15,22 @@ import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.io.File;
 import java.util.HashSet;
 
 import cn.classfun.droidvm.R;
 import cn.classfun.droidvm.lib.store.base.DataItem;
+import cn.classfun.droidvm.lib.store.disk.DiskBus;
+import cn.classfun.droidvm.lib.store.enums.Enums;
+import cn.classfun.droidvm.lib.store.vm.VMBackend;
 import cn.classfun.droidvm.lib.store.vm.VMConfig;
 import cn.classfun.droidvm.lib.store.vm.VMStore;
 import cn.classfun.droidvm.ui.disk.action.DiskActionDialog;
 import cn.classfun.droidvm.ui.vm.edit.VMEditActivity;
 import cn.classfun.droidvm.ui.vm.edit.base.VMEditBaseTab;
+import cn.classfun.droidvm.ui.vm.edit.base.VMEditTab;
+import cn.classfun.droidvm.ui.vm.edit.basic.VMEditBasicTab;
+import cn.classfun.droidvm.ui.vm.edit.boot.VMEditBootTab;
 import cn.classfun.droidvm.ui.vm.edit.storage.dir.VMSharedDirEditAdapter;
 import cn.classfun.droidvm.ui.vm.edit.storage.disk.VMDiskEditAdapter;
 import cn.classfun.droidvm.ui.widgets.container.CardItemListView;
@@ -53,8 +61,22 @@ public final class VMEditStorageTab extends VMEditBaseTab {
         diskAdapter = listDisks.setAdapter(VMDiskEditAdapter.class);
         diskAdapter.setOnBrowseFileListener(this::diskAdapterOnBrowseFile);
         diskAdapter.setOnImportOrCreateListener(this::diskAdapterOnImportOrCreate);
+        // no PFLASH while the boot tab's UEFI vars pflash is enabled
+        diskAdapter.setUefiVarsEnabledProvider(() -> {
+            try {
+                var boot = (VMEditBootTab) parent.getTab(VMEditTab.TAB_BOOT);
+                return boot == null || boot.isVarsEnabledLive();
+            } catch (Exception e) {
+                return true;
+            }
+        });
         sharedDirAdapter = listSharedDirs.setAdapter(VMSharedDirEditAdapter.class);
         sharedDirAdapter.setOnBrowseListener(this::sharedDirAdapterOnBrowse);
+    }
+
+    // Refresh disk rows; PFLASH availability may have changed.
+    public void refreshDisks() {
+        if (diskAdapter != null) diskAdapter.notifyDataSetChanged();
     }
 
     private void diskAdapterOnImportOrCreate(int pos) {
@@ -128,9 +150,18 @@ public final class VMEditStorageTab extends VMEditBaseTab {
 
     @Override
     public boolean validateInput(@NonNull VMStore store) {
-        for (var disk : diskAdapter.getItems())
-            if (!checkFilePath(disk.getValue().optString("path", ""), true))
+        var crosvm = currentBackend() == VMBackend.CROSVM;
+        for (var disk : diskAdapter.getItems()) {
+            var d = disk.getValue();
+            var path = d.optString("path", "");
+            if (!checkFilePath(path, true))
                 return showValidateFailed(R.string.edit_vm_target_disk_path_invalid);
+            // crosvm-only pflash size limit
+            if (crosvm && Enums.optEnum(d, "bus", DiskBus.VIRTIO) == DiskBus.PFLASH
+                && new File(path).length() > PFLASH_MAX_SIZE)
+                return showValidateFailed(parent.getString(
+                    R.string.edit_vm_uefi_vars_too_large, PFLASH_MAX_SIZE / (1024 * 1024)));
+        }
         var set = new HashSet<String>();
         for (var dir : sharedDirAdapter.getItems()) {
             var d = dir.getValue();
@@ -144,6 +175,17 @@ public final class VMEditStorageTab extends VMEditBaseTab {
             set.add(tag);
         }
         return true;
+    }
+
+    /** The backend as currently selected in the basic tab (before save). */
+    @NonNull
+    private VMBackend currentBackend() {
+        try {
+            var basic = (VMEditBasicTab) parent.getTab(VMEditTab.TAB_BASIC);
+            if (basic != null) return basic.getCurrentBackend();
+        } catch (Exception ignored) {
+        }
+        return VMBackend.DEFAULT;
     }
 
     @Override

--- a/app/src/main/java/cn/classfun/droidvm/ui/vm/edit/storage/disk/VMDiskEditAdapter.java
+++ b/app/src/main/java/cn/classfun/droidvm/ui/vm/edit/storage/disk/VMDiskEditAdapter.java
@@ -16,6 +16,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import cn.classfun.droidvm.R;
+import cn.classfun.droidvm.lib.store.base.DataItem;
 import cn.classfun.droidvm.lib.store.disk.DiskBus;
 import cn.classfun.droidvm.lib.store.disk.DiskStore;
 import cn.classfun.droidvm.lib.store.enums.Enums;
@@ -25,8 +26,14 @@ import cn.classfun.droidvm.ui.main.disk.DiskAdapter;
 import cn.classfun.droidvm.ui.widgets.container.CardItemAdapter;
 
 public final class VMDiskEditAdapter extends CardItemAdapter<VMDiskEditViewHolder> {
+    @FunctionalInterface
+    public interface UefiVarsEnabledProvider {
+        boolean isEnabled();
+    }
+
     private OnItemClickListener browseFileListener;
     private OnItemClickListener importOrCreateListener;
+    private UefiVarsEnabledProvider uefiVarsEnabledProvider = () -> true;
     private boolean readonlyChanged = false;
     private boolean updatingViews = false;
 
@@ -45,6 +52,35 @@ public final class VMDiskEditAdapter extends CardItemAdapter<VMDiskEditViewHolde
 
     public void setOnImportOrCreateListener(OnItemClickListener l) {
         this.importOrCreateListener = l;
+    }
+
+    public void setUefiVarsEnabledProvider(@NonNull UefiVarsEnabledProvider provider) {
+        this.uefiVarsEnabledProvider = provider;
+    }
+
+    private boolean pflashAllowed(int position) {
+        if (uefiVarsEnabledProvider.isEnabled()) return false;
+        for (int i = 0; i < items.size(); i++) {
+            if (i == position) continue;
+            var d = items.get(i);
+            if (d.is(DataItem.Type.OBJECT)
+                && Enums.optEnum(d, "bus", DiskBus.VIRTIO) == DiskBus.PFLASH)
+                return false;
+        }
+        return true;
+    }
+
+    @NonNull
+    private DiskBus[] busOptions(int position) {
+        if (!pflashAllowed(position))
+            return new DiskBus[]{DiskBus.VIRTIO, DiskBus.SCSI, DiskBus.PMEM, DiskBus.CDROM};
+        return new DiskBus[]{DiskBus.VIRTIO, DiskBus.SCSI, DiskBus.PMEM, DiskBus.CDROM, DiskBus.PFLASH};
+    }
+
+    private static boolean containsPflash(@NonNull DiskBus[] options) {
+        for (var bus : options)
+            if (bus == DiskBus.PFLASH) return true;
+        return false;
     }
 
     public void setPathAt(int position, String path) {
@@ -98,7 +134,15 @@ public final class VMDiskEditAdapter extends CardItemAdapter<VMDiskEditViewHolde
         holder.unbindWatcher();
         holder.etPath.setText(disk.optString("path", ""));
         holder.switchReadonly.setChecked(disk.optBoolean("readonly", false));
-        holder.btnBus.configure(DiskBus.class, Enums.optEnum(disk, "bus", DiskBus.VIRTIO));
+        // unselectable PFLASH and fallback to VIRTIO.
+        var bus = Enums.optEnum(disk, "bus", DiskBus.VIRTIO);
+        var options = busOptions(position);
+        if (bus == DiskBus.PFLASH && !containsPflash(options)) {
+            bus = DiskBus.VIRTIO;
+            if (!updatingViews) disk.set("bus", bus);
+        }
+        holder.btnBus.setItems(options);
+        holder.btnBus.setSelectedItem(bus);
         holder.btnBus.setOnValueChangedListener((oldVal, newVal) -> {
             if (updatingViews) return;
             int pos = holder.getBindingAdapterPosition();
@@ -108,7 +152,14 @@ public final class VMDiskEditAdapter extends CardItemAdapter<VMDiskEditViewHolde
             if (!readonlyChanged)
                 item.set("readonly", newVal == DiskBus.CDROM);
             try {
-                notifyItemChanged(pos);
+                // PFLASH exclusivity changes other rows' options, so a
+                // PFLASH switch needs a full refresh; any other
+                // bus change only affects this row.
+                if (oldVal == DiskBus.PFLASH || newVal == DiskBus.PFLASH) {
+                    notifyDataSetChanged();
+                } else {
+                    notifyItemChanged(pos);
+                }
             } catch (Exception ignored) {
             }
         });
@@ -135,8 +186,14 @@ public final class VMDiskEditAdapter extends CardItemAdapter<VMDiskEditViewHolde
         });
         holder.btnDelete.setOnClickListener(v -> {
             int pos = holder.getBindingAdapterPosition();
-            if (pos != RecyclerView.NO_POSITION)
+            if (pos != RecyclerView.NO_POSITION) {
                 removeItem(pos);
+                // re-enable PFLASH for the remaining rows if it was the only one
+                try {
+                    notifyDataSetChanged();
+                } catch (Exception ignored) {
+                }
+            }
         });
     }
 

--- a/app/src/main/res/layout/partial_vm_edit_boot.xml
+++ b/app/src/main/res/layout/partial_vm_edit_boot.xml
@@ -36,6 +36,25 @@
             app:ti_iconButtonHint="@string/edit_vm_disk_browse"
             app:ti_iconButtonIcon="@drawable/ic_open_in" />
 
+        <cn.classfun.droidvm.ui.widgets.row.SwitchRowWidget
+            android:id="@+id/sw_uefi_vars_enabled"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:checked="true"
+            android:icon="@drawable/ic_nav_disk"
+            android:text="@string/edit_vm_uefi_vars_enabled"
+            android:subtitle="@string/edit_vm_uefi_vars_enabled_subtitle" />
+
+        <cn.classfun.droidvm.ui.widgets.row.TextInputRowWidget
+            android:id="@+id/input_uefi_vars"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/edit_vm_uefi_vars"
+            android:icon="@drawable/ic_nav_disk"
+            android:inputType="text"
+            app:ti_iconButtonHint="@string/edit_vm_disk_browse"
+            app:ti_iconButtonIcon="@drawable/ic_open_in" />
+
         <TextView
             android:id="@+id/tv_uefi_hint"
             android:layout_width="match_parent"

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -298,6 +298,11 @@
     <string name="edit_vm_uefi_firmware_builtin">内置 EDK2</string>
     <string name="edit_vm_uefi_firmware_browse_title">选择 UEFI 固件</string>
     <string name="edit_vm_uefi_firmware_hint">自定义固件仅对 QEMU 后端生效\ncrosvm 始终使用内置 EDK2\nUEFI 引导 Linux 适配中,尚不可用;如需引导 Linux,请选择 Linux 内核引导方式</string>
+    <string name="edit_vm_uefi_vars">UEFI 变量(留空 = 内置 EDK2 变量)</string>
+    <string name="edit_vm_uefi_vars_browse_title">选择 UEFI 变量文件</string>
+    <string name="edit_vm_uefi_vars_too_large">对于 crosvm,pflash 镜像大小不能超过 %1$d MiB</string>
+    <string name="edit_vm_uefi_vars_enabled">启用 UEFI 变量(pflash)</string>
+    <string name="edit_vm_uefi_vars_enabled_subtitle">挂载 UEFI 变量存储。启用后,存储分区中不可再选择 PFLASH 总线。</string>
     <string name="edit_vm_kernel_source">内核来源</string>
     <string name="edit_vm_kernel_source_image">磁盘镜像</string>
     <string name="edit_vm_kernel_source_manual">手动指定</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -298,6 +298,11 @@
     <string name="edit_vm_uefi_firmware_builtin">內建 EDK2</string>
     <string name="edit_vm_uefi_firmware_browse_title">選擇 UEFI 韌體</string>
     <string name="edit_vm_uefi_firmware_hint">自定義韌體僅對 QEMU 後端生效\ncrosvm 始終使用內建 EDK2\nUEFI 引導 Linux 適配中,尚不可用;如需引導 Linux,請選擇 Linux 核心引導方式</string>
+    <string name="edit_vm_uefi_vars">UEFI 變數(留空 = 內建 EDK2 變數)</string>
+    <string name="edit_vm_uefi_vars_browse_title">選擇 UEFI 變數檔案</string>
+    <string name="edit_vm_uefi_vars_too_large">對於 crosvm,pflash 鏡像大小不能超過 %1$d MiB</string>
+    <string name="edit_vm_uefi_vars_enabled">啟用 UEFI 變數(pflash)</string>
+    <string name="edit_vm_uefi_vars_enabled_subtitle">掛載 UEFI 變數儲存。啟用後,儲存區中不可再選擇 PFLASH 匯流排。</string>
     <string name="edit_vm_kernel_source">核心來源</string>
     <string name="edit_vm_kernel_source_image">磁碟映像</string>
     <string name="edit_vm_kernel_source_manual">手動指定</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -300,6 +300,11 @@
     <string name="edit_vm_uefi_firmware_builtin">Built-in EDK2</string>
     <string name="edit_vm_uefi_firmware_browse_title">Select UEFI firmware</string>
     <string name="edit_vm_uefi_firmware_hint">Custom firmware only takes effect on the QEMU backend\ncrosvm always uses the built-in EDK2\nBooting Linux via UEFI is still being adapted and is not usable yet -- to boot Linux, choose the Linux kernel boot protocol</string>
+    <string name="edit_vm_uefi_vars">UEFI vars (empty = built-in EDK2 vars)</string>
+    <string name="edit_vm_uefi_vars_browse_title">Select UEFI vars</string>
+    <string name="edit_vm_uefi_vars_too_large">For crosvm, pflash image size must not exceed %1$d MiB</string>
+    <string name="edit_vm_uefi_vars_enabled">Enable UEFI vars (pflash)</string>
+    <string name="edit_vm_uefi_vars_enabled_subtitle">Attach the UEFI variable store. While enabled, the PFLASH bus is unavailable in the storage section.</string>
     <string name="edit_vm_kernel_source">Kernel source</string>
     <string name="edit_vm_kernel_source_image">Disk image</string>
     <string name="edit_vm_kernel_source_manual">Manual</string>


### PR DESCRIPTION
Crosvm only support 1 pflash and the size of it can not be greater than 8MB. For qemu, the num of pflash is 2 and there is no size limit. This commit constrains pflash num to 1 for both qemu and crosvm, and limit size to 8MB for only crosvm.

- Add UEFI vars (pflash) config under boot.uefi: vars path + vars_enabled switch; empty vars = built-in edk2-gunyah.vars.fd (shared crosvm/QEMU)
- crosvm backend: attach --pflash with auto block size when vars enabled; QEMU backend: attach -drive if=pflash with the same vars file
- Boot tab UI: enable switch + vars path row (empty = built-in), browse dialog for custom vars file; hint text moved above the switch
- Storage tab: PFLASH bus hidden while UEFI vars pflash is enabled; only one PFLASH disk allowed (mutual exclusion), auto-downgrade to VIRTIO
- Validate pflash image size (8 MiB crosvm limit) on save for both the boot vars file and storage PFLASH disks; QEMU backend exempt
- Add VMBackend accessor on the basic tab for cross-tab backend checks

The new option under uefi section:
<img width="2271" height="1474" alt="QQ_1786891456484" src="https://github.com/user-attachments/assets/0fa56524-1c14-4954-b909-21eb8cfbf1a2" />
